### PR TITLE
Clean up incorrect pluralization of Attribute (a repeated typo).

### DIFF
--- a/lib/virtus.rb
+++ b/lib/virtus.rb
@@ -22,7 +22,7 @@ module Virtus
     base.send(:include, InstanceMethods)
   end
 
-  # Returns a Virtus::Attributes::Object sub-class based on a name or class
+  # Returns a Virtus::Attribute::Object sub-class based on a name or class
   #
   # @example
   #   Virtus.determine_type('String') # => Virtus::Attribute::String
@@ -31,7 +31,7 @@ module Virtus
   #   name of a class or a class itself
   #
   # @return [Class]
-  #   one of the Virtus::Attributes::Object sub-class
+  #   one of the Virtus::Attribute::Object sub-class
   #
   # @api semipublic
   def self.determine_type(class_or_name)

--- a/lib/virtus/attribute/array.rb
+++ b/lib/virtus/attribute/array.rb
@@ -14,5 +14,5 @@ module Virtus
       primitive ::Array
       complex   true
     end # class Array
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/boolean.rb
+++ b/lib/virtus/attribute/boolean.rb
@@ -68,5 +68,5 @@ module Virtus
       end
 
     end # class Boolean
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/date.rb
+++ b/lib/virtus/attribute/date.rb
@@ -33,5 +33,5 @@ module Virtus
       end
 
     end # class Date
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/date_time.rb
+++ b/lib/virtus/attribute/date_time.rb
@@ -32,5 +32,5 @@ module Virtus
       end
 
     end # class DateTim
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/decimal.rb
+++ b/lib/virtus/attribute/decimal.rb
@@ -22,5 +22,5 @@ module Virtus
       end
 
     end # class Decimal
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/float.rb
+++ b/lib/virtus/attribute/float.rb
@@ -31,5 +31,5 @@ module Virtus
       end
 
     end # class Float
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/hash.rb
+++ b/lib/virtus/attribute/hash.rb
@@ -15,5 +15,5 @@ module Virtus
       primitive ::Hash
       complex   true
     end # class Hash
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/integer.rb
+++ b/lib/virtus/attribute/integer.rb
@@ -28,5 +28,5 @@ module Virtus
       end
 
     end # class Integer
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/numeric.rb
+++ b/lib/virtus/attribute/numeric.rb
@@ -6,5 +6,5 @@ module Virtus
       primitive      ::Numeric
       accept_options :min, :max
     end # class Numeric
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/object.rb
+++ b/lib/virtus/attribute/object.rb
@@ -4,6 +4,6 @@ module Virtus
     # Base class for every attribute
     class Object < Attribute
       primitive ::Object
-    end # class Objec
-  end # class Attributes
+    end # class Object
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/string.rb
+++ b/lib/virtus/attribute/string.rb
@@ -25,5 +25,5 @@ module Virtus
       end
 
     end # class String
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/attribute/time.rb
+++ b/lib/virtus/attribute/time.rb
@@ -32,5 +32,5 @@ module Virtus
       end
 
     end # class Time
-  end # class Attributes
+  end # class Attribute
 end # module Virtus

--- a/lib/virtus/class_methods.rb
+++ b/lib/virtus/class_methods.rb
@@ -71,7 +71,7 @@ module Virtus
     #
     # It is used when an attribute is defined and a global class like String
     # or Integer is provided as the type which needs to be mapped to
-    # Virtus::Attributes::String and Virtus::Attributes::Integer
+    # Virtus::Attribute::String and Virtus::Attribute::Integer
     #
     # @param [String] name
     #


### PR DESCRIPTION
Noticed because I was just debating with @dkubb about the merits of nesting subclasses within an abstract superclass vs. nesting them within a module with a pluralized version of the abstract superclass name. 

In Virtus, that means I would advocate nesting Attribute descendants in a module called Attributes, instead of directly within Attribute itself. 

_But_, if they're going to be nested inside of Attribute, at least I can clean up the comments on the `end` lines to be accurate.
