### PR TITLE
Simplified true/false lookup tables

### DIFF
--- a/lib/virtus/typecast/boolean.rb
+++ b/lib/virtus/typecast/boolean.rb
@@ -5,8 +5,8 @@ module Virtus
     # See TRUE_VALUES and FALSE_VALUES constants for a reference.
     class Boolean
 
-      TRUE_VALUES  = [ 1, '1', 't', 'T', 'true',  'TRUE'  ].freeze
-      FALSE_VALUES = [ 0, '0', 'f', 'F', 'false', 'FALSE' ].freeze
+      TRUE_VALUES  = %w[ 1 t true  ].freeze
+      FALSE_VALUES = %w[ 0 f false ].freeze
       BOOLEAN_MAP  = Hash[ TRUE_VALUES.product([ true ]) + FALSE_VALUES.product([ false ]) ].freeze
 
       # Typecast value to TrueClass or FalseClass
@@ -15,13 +15,13 @@ module Virtus
       #   Virtus::Typecast::Boolean.call('T')  # => true
       #   Virtus::Typecast::Boolean.call('F')  # => false
       #
-      # @param [Integer, String]
+      # @param [#to_s]
       #
       # @return [Boolean]
       #
       # @api public
       def self.call(value)
-        BOOLEAN_MAP.fetch(value, value)
+        BOOLEAN_MAP.fetch(value.to_s.downcase, value)
       end
 
     end # class Boolean


### PR DESCRIPTION
- A simpler approach is just to take the downcased, string representation of
  the boolean-like value and map it to either true or false.
