### PR TITLE
Only require 'backports' on Ruby 1.8.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-require 'backports'
+require 'backports' if RUBY_VERSION < '1.9'
 require 'pathname'
 require 'rubygems'
 require 'rspec'


### PR DESCRIPTION
This will help us catch Ruby 1.9 vs. backports incompatibilities.
