### PR TITLE
explicilty require 'set' to get the specs working

### DIFF
--- a/lib/virtus.rb
+++ b/lib/virtus.rb
@@ -1,3 +1,4 @@
+require 'set'
 require 'date'
 require 'time'
 require 'bigdecimal'


### PR DESCRIPTION
I just cloned the project and tried running the specs and got a lot of NameErrors

```
NameError:
       uninitialized constant RSpec::Core::ExampleGroup::Nested_22::Nested_2::Nested_2::Set
```

I saw in the specs that you expect the Class `AttributeSet` to respond to `to_set`. 

```
    its(:to_set) { should == Set[ attribute ] }
```

Since this is defined in the set-library from Std.-Lib I added a require statement to the virtus init-file.
