### PR TITLE
fix a typo in the README to showoff the default values

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ class Page
 
   attribute :title, String
   attribute :views, Integer, :default => 0
-  attribute :slug, String, :default => lambda { |post, attribute| post.title.downcase.gsub(' ', '-') }
+  attribute :slug, String, :default => lambda { |page, attribute| page.title.downcase.gsub(' ', '-') }
 end
 
 page = Page.new :title => 'Virtus Is Awesome'


### PR DESCRIPTION
fixed a small typo to clarify the meaning of the default-value examples in the README file.
