### PR TITLE
partition specs into multiple suites

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,19 @@ require 'rspec/core/rake_task'
 
 FileList['tasks/**/*.rake'].each { |task| import task }
 
+namespace :spec do
+  RSpec::Core::RakeTask.new(:examples) do |t|
+    t.pattern = 'examples/**/*_spec.rb'
+  end
+
+  RSpec::Core::RakeTask.new(:integration) do |t|
+    t.pattern = 'spec/integration/**/*_spec.rb'
+  end
+
+  RSpec::Core::RakeTask.new(:unit) do |t|
+    t.pattern = 'spec/unit/**/*_spec.rb'
+  end
+end
+
 desc 'Default: run specs.'
-task :default => :spec
+task :default => ['spec:unit', 'spec:integration', 'spec:examples']


### PR DESCRIPTION
I created 3 spec suites:
- unit => rake spec:unit
- integration => rake spec:integration
- examples => rake spec:examples

calling 'rake' without arguments runs them all in sequence
