### PR TITLE
partition specs into multiple suites

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
 require 'rubygems'
 require 'rake'
-require 'rspec/core/rake_task'
 
 FileList['tasks/**/*.rake'].each { |task| import task }
 
-desc 'Default: run specs.'
+desc 'Default: run all specs'
 task :default => :spec

--- a/tasks/spec.rake
+++ b/tasks/spec.rake
@@ -1,7 +1,22 @@
 begin
   require 'rspec/core/rake_task'
 
-  RSpec::Core::RakeTask.new(:spec)
+  desc 'run all specs'
+  task :spec => ['spec:unit', 'spec:integration', 'spec:examples']
+
+  namespace :spec do
+    RSpec::Core::RakeTask.new(:examples) do |t|
+      t.pattern = 'examples/**/*_spec.rb'
+    end
+
+    RSpec::Core::RakeTask.new(:integration) do |t|
+      t.pattern = 'spec/integration/**/*_spec.rb'
+    end
+
+    RSpec::Core::RakeTask.new(:unit) do |t|
+      t.pattern = 'spec/unit/**/*_spec.rb'
+    end
+  end
 rescue LoadError
   task :spec do
     abort 'rspec is not available. In order to run spec, you must: gem install rspec'
@@ -22,5 +37,4 @@ rescue LoadError
   end
 end
 
-task :test    => :spec
-task :default => :spec
+task :test    => 'spec'


### PR DESCRIPTION
I created 3 spec suites:
- unit => rake spec:unit
- integration => rake spec:integration
- examples => rake spec:examples

calling 'rake' without arguments runs them all in sequence
