### PR TITLE
allow to override attribute setters/getters

### DIFF
--- a/examples/override_attribute_methods_spec.rb
+++ b/examples/override_attribute_methods_spec.rb
@@ -1,0 +1,40 @@
+require './spec/spec_helper'
+
+class Article
+  include Virtus
+
+  attribute :author, String
+
+  def author
+    super || '<unknown>'
+  end
+
+  def author=(name)
+    super unless name == 'Brad'
+  end
+
+end
+
+describe Article, 'override' do
+
+  it 'Alice is an allowed author' do
+    Article.new(:author => 'Alice').author.should == 'Alice'
+  end
+
+  it 'Brad isn not an allowed author' do
+    Article.new(:author => 'Brad').author.should == '<unknown>'
+  end
+
+  context 'with author' do
+    subject { Article.new(:author => 'John') }
+
+    its(:author) { should == 'John' }
+  end
+
+  context 'without author' do
+    subject { Article.new }
+
+    its(:author) { should == '<unknown>' }
+  end
+
+end

--- a/lib/virtus/class_methods.rb
+++ b/lib/virtus/class_methods.rb
@@ -99,9 +99,12 @@ module Virtus
     #
     # @api private
     def virtus_define_attribute_methods(attribute)
-      attribute.define_reader_method(self)
-      attribute.define_writer_method(self)
-      include self::AttributeMethods
+      module_with_methods = self::AttributeMethods
+
+      attribute.define_reader_method(module_with_methods)
+      attribute.define_writer_method(module_with_methods)
+
+      include module_with_methods
     end
 
     # Add the attribute to the class' and descendants' attributes


### PR DESCRIPTION
It should be possible to override attribute getters/setters defined by Virtus.

``` ruby
class Article
  include Virtus

  attribute :author, String

  def author
    super || '<unknown>'
  end

  def author=(name)
    super unless name == 'Brad'
  end
end
```
