### PR TITLE
integration spec for default-values based on private attributes

### DIFF
--- a/spec/integration/default_values_spec.rb
+++ b/spec/integration/default_values_spec.rb
@@ -10,6 +10,10 @@ describe "default values" do
         attribute :title,      String
         attribute :slug,       String,  :default => lambda { |post, attribute| post.title.downcase.gsub(' ', '-') }
         attribute :view_count, Integer, :default => 0
+        attribute :published,  Boolean, :accessor => :private, :default => false
+        attribute :editor_title, String, :default => lambda { |post, attribute|
+          post.published? ? post.title : "UNPUBLISHED: #{post.title}"
+        }
       end
     end
   end
@@ -27,6 +31,11 @@ describe "default values" do
   specify "you can pass a 'callable-object' to the :default option" do
     subject.title = 'Example Blog Post'
     subject.slug.should == 'example-blog-post'
+  end
+
+  specify 'you can set defaults for private attributes' do
+    subject.title = 'Top Secret'
+    subject.editor_title.should == 'UNPUBLISHED: Top Secret'
   end
 
 end


### PR DESCRIPTION
This is a spec related to #32.

It is possible that there is a working way around the problem. If so, I suggest modifying the spec to pass and keep it in the suite so that it won't break in the future.
