### PR TITLE
Use EmbeddedValue#primitive instead of #model

### DIFF
--- a/lib/virtus/attribute/embedded_value.rb
+++ b/lib/virtus/attribute/embedded_value.rb
@@ -25,6 +25,7 @@ module Virtus
     #     :street => 'Street 1/2', :zipcode => '12345', :city => 'NYC' })
     #
     class EmbeddedValue < Object
+      primitive       ::OpenStruct
 
       # @see Attribute.merge_options
       #
@@ -33,19 +34,7 @@ module Virtus
       #
       # @api private
       def self.merge_options(type, options)
-        options.merge(:model => type)
-      end
-
-      # Sets @model ivar
-      #
-      # @see Virtus::Attribute#initialize
-      #
-      # @return [undefined]
-      #
-      # @api private
-      def initialize(name, options = {})
-        super
-        @model = options.fetch(:model, OpenStruct)
+        options.merge(:primitive => type)
       end
 
       # Coerce attributes into a virtus object
@@ -57,7 +46,7 @@ module Virtus
       # @api private
       def coerce(attributes_or_object)
         value = if attributes_or_object.kind_of?(::Hash)
-                  @model.new(attributes_or_object)
+                  @primitive.new(attributes_or_object)
                 else
                   attributes_or_object
                 end

--- a/spec/unit/virtus/attribute/class_methods/determine_type_spec.rb
+++ b/spec/unit/virtus/attribute/class_methods/determine_type_spec.rb
@@ -17,7 +17,7 @@ describe Virtus::Attribute, '.determine_type' do
       subject { object.determine_type(primitive) }
 
       before do
-        if [Virtus::Attribute::EmbeddedValue, Virtus::Attribute::Collection].include? attribute_class
+        if [Virtus::Attribute::Collection].include? attribute_class
           pending
         end
       end

--- a/spec/unit/virtus/attribute/embedded_value/class_methods/merge_options_spec.rb
+++ b/spec/unit/virtus/attribute/embedded_value/class_methods/merge_options_spec.rb
@@ -12,6 +12,6 @@ describe Virtus::Attribute::EmbeddedValue, '.merge_options' do
   it { should_not equal(options) }
 
   it 'merges the type in as the model' do
-    should eql(:model => type)
+    should eql(:primitive => type)
   end
 end

--- a/spec/unit/virtus/attribute/embedded_value/coerce_spec.rb
+++ b/spec/unit/virtus/attribute/embedded_value/coerce_spec.rb
@@ -11,7 +11,7 @@ describe Virtus::Attribute::EmbeddedValue, '#coerce' do
     let(:value) { Hash[:foo => 'bar'] }
 
     context 'when the options include the model' do
-      let(:object)         { described_class.new(attribute_name, :model => model) }
+      let(:object)         { described_class.new(attribute_name, :primitive => model) }
       let(:model)          { mock('model')                                        }
       let(:model_instance) { mock('model_instance') }
 


### PR DESCRIPTION
The model attribute for EmbeddedValue had some kind of duplicated the
primitive lookup. Now OpenStruct is the default primitive for embedded
values, the user model still takes precedence.

This pull request removes EmbeddedValue#model and uses EmbeddedValue#primitive.

This is needed so I can use Aequitas Rule::PrimitiveType::Virtus. Aequitas uses EmbeddedValue#value_coerced?(value) internaly. Before this patch EmbeddedValue#primitive always returns ::Object, so value_ocerced?(value) always fails.

It would also be possible to simply override Attribute#value_coerced to not compare @primitive === value, and instead doing @model === value. But IMHO it is better to remove code than to add. My pull request uses the present "Primitive" infrastructure this is the way to go.

As a side note, since I needed to use OpenStruct as default primitive, I could remove the pending spec on Attribute.detect_type whith embedded values.

Feel free to comment, since this is my first contribution to virtus it is likely I missed some important points.
