### PR TITLE
Fix build status and add dependency status image to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 virtus
 ======
 
-[![Build Status](http://travis-ci.org/solnic/virtus.png)](http://travis-ci.org/solnic/virtus)
+[![Build Status](https://secure.travis-ci.org/solnic/virtus.png)](http://travis-ci.org/solnic/virtus)
+[![Dependency Status](https://gemnasium.com/solnic/virtus.png)](https://gemnasium.com/solnic/virtus)
 
 [Metrics on CodeClimate](https://codeclimate.com/github/solnic/virtus)
 


### PR DESCRIPTION
Fetching the Travis image over HTTP can cause caching issues on GitHub.
