### PR TITLE
Require backports after rubygems so that ruby 1.8 finds it

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-require 'backports'
 require 'rubygems'
+require 'backports'
 
 begin
   require 'rspec'  # try for RSpec 2


### PR DESCRIPTION
I had `spec_helper.rb` dirty since I started playing with Virtus code and ended up not pointing this out to you guys.

```
$ rake
/home/fabio/projetos/oss/virtus/spec/spec_helper.rb:1:in `require': no such file to load -- backports (LoadError)
    from /home/fabio/projetos/oss/virtus/spec/spec_helper.rb:1
    from ./spec/unit/virtus/value_object/class_methods/equalizer_spec.rb:1:in `require'
    from ./spec/unit/virtus/value_object/class_methods/equalizer_spec.rb:1
    from /home/fabio/.rvm/gems/ruby-1.8.7-p334@virtus/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:15:in `load'
    from /home/fabio/.rvm/gems/ruby-1.8.7-p334@virtus/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:15:in `load_files'
    from /home/fabio/.rvm/gems/ruby-1.8.7-p334@virtus/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:14:in `each'
    from /home/fabio/.rvm/gems/ruby-1.8.7-p334@virtus/gems/rspec-1.3.2/lib/spec/runner/example_group_runner.rb:14:in `load_files'
    from /home/fabio/.rvm/gems/ruby-1.8.7-p334@virtus/gems/rspec-1.3.2/lib/spec/runner/options.rb:134:in `run_examples'
    from /home/fabio/.rvm/gems/ruby-1.8.7-p334@virtus/gems/rspec-1.3.2/lib/spec/runner/command_line.rb:9:in `run'
    from /home/fabio/.rvm/gems/ruby-1.8.7-p334@virtus/gems/rspec-1.3.2/bin/spec:5
rake aborted!
```
