### PR TITLE
Adding recursive #to_hash implementation and spec.

### DIFF
--- a/lib/virtus/instance_methods.rb
+++ b/lib/virtus/instance_methods.rb
@@ -112,7 +112,8 @@ module Virtus
       set_attributes(attributes)
     end
 
-    # Returns a hash of all publicly accessible attributes
+    # Returns a hash of all publicly accessible attributes by
+    # recursively calling #to_hash on the objects that respond to it.
     #
     # @example
     #   class User
@@ -129,7 +130,13 @@ module Virtus
     #
     # @api public
     def to_hash
-      attributes
+      attrs = attributes.dup
+      attrs.each do |key, value|
+        if value.respond_to?(:to_hash)
+          hash[key] = value.to_hash
+        end
+      end
+      attrs
     end
 
   private

--- a/spec/unit/virtus/instance_methods/to_hash_spec.rb
+++ b/spec/unit/virtus/instance_methods/to_hash_spec.rb
@@ -3,17 +3,29 @@ require 'spec_helper'
 describe Virtus::InstanceMethods, '#to_hash' do
   subject { object.to_hash }
 
-  class Model
+  class Address
     include Virtus
 
-    attribute :name,  String
-    attribute :age,   Integer
-    attribute :email, String, :accessor => :private
+    attribute :street,  String
+    attribute :city,    String
   end
 
-  let(:model)      { Model                           }
-  let(:object)     { model.new(attributes)           }
-  let(:attributes) { { :name => 'john', :age => 28 } }
+  class Person
+    include Virtus
+
+    attribute :name,    String
+    attribute :age,     Integer
+    attribute :email,   String, :accessor => :private
+    attribute :address, Address
+  end
+
+  let(:model)        { Person                          }
+  let(:child_record) { Address                         }
+
+  let(:address)    { { :street => "Sunshinestr.", :city => "Berlin" } }
+  let(:object)     { model.new(attributes)                            }
+
+  let(:attributes) { { :name => 'john', :age => 28, :address => child_record } }
 
   it { should be_instance_of(Hash) }
 


### PR DESCRIPTION
Makes API more consistent. Now, if record was created from
some hash, it will get serialized back to same hash.

Closes #82.
