### PR TITLE
Support DataMapper :required option

### DIFF
--- a/lib/virtus/attribute.rb
+++ b/lib/virtus/attribute.rb
@@ -9,7 +9,7 @@ module Virtus
     extend Options
 
     accept_options :primitive, :accessor, :reader,
-      :writer, :coercion_method, :default
+      :writer, :coercion_method, :default, :required
 
     accessor :public
 


### PR DESCRIPTION
DataMapper supports a :required option that allows you to specify properties that might be present, but might not be. This is very useful in scenarios where your property is some type that can throw exceptions for certain values when you coerce it to its native type. 

Instead of having to implement error handling on all of your custom attributes that implement `coerce`, you can mark that attribute as being optional and handle the case where it isn't available outside the model itself.

For example, you might have a custom property that takes ruby Strings (from the network, a database, or some other source) and coerces them to a UUID. UUIDs have very specific formatting rules, so if you pass it an empty string, or something that doesn't match a UUID at all, it will likely throw an exception. 

``` ruby
class TestModel
  include Virtus
  attribute :name, String
  attribute :uuid, UUID, :required => false 
end

object = TestModel.new(:name => 'foo') # works, uuid is nil
object = TestModel.new(:name => 'bar', :uuid => nil) # fails, cannot cast nil to UUID
```
