### PR TITLE
Bump backports dep to ~> 2.6.1

### DIFF
--- a/virtus.gemspec
+++ b/virtus.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.test_files       = `git ls-files -- {spec}/*`.split("\n")
   gem.extra_rdoc_files = %w[LICENSE README.md TODO]
 
-  gem.add_runtime_dependency('backports', '~> 2.5.3')
+  gem.add_runtime_dependency('backports', '~> 2.6.1')
 
   gem.add_development_dependency('rake',        '~> 0.9.2')
   gem.add_development_dependency('rspec',       '~> 1.3.2')


### PR DESCRIPTION
This makes virtus coexist peacefully with lastest
dm-core and veritas related master sources.
