### PR TITLE
Fix spec failure due to stub conversion to string.

### DIFF
--- a/spec/unit/virtus/instance_methods/initialize_spec.rb
+++ b/spec/unit/virtus/instance_methods/initialize_spec.rb
@@ -27,7 +27,7 @@ describe Virtus::InstanceMethods, '#initialize' do
   context 'with an argument that responds to #to_hash' do
     subject { described_class.new(:name => name) }
 
-    let(:name) { stub('name') }
+    let(:name) { 'name' }
 
     it 'sets attributes' do
       subject.name.should be(name)


### PR DESCRIPTION
This test was failing because the name attribute was specified as a string
and the subject.name was being compared to the name stub (of class
RSpec::Mock) rather than another string and thus was failing.

It appears that this has come up in the past (specifically #78) and is caused
by the fact that RSpec::Mock implements `to_str`.
