### PR TITLE
Disallow mutation of ValueObjects via #attributes=

### DIFF
--- a/lib/virtus/value_object.rb
+++ b/lib/virtus/value_object.rb
@@ -35,6 +35,7 @@ module Virtus
         include ::Virtus
         include InstanceMethods
         extend ClassMethods
+        private :attributes=
       end
     end
 

--- a/spec/integration/virtus/value_object_spec.rb
+++ b/spec/integration/virtus/value_object_spec.rb
@@ -40,7 +40,7 @@ describe Virtus::ValueObject do
     it 'writer methods are set to private' do
       private_methods = class_under_test.private_instance_methods
       private_methods.map! { |m| m.to_s }
-      private_methods.should include('latitude=', 'longitude=')
+      private_methods.should include('latitude=', 'longitude=', 'attributes=')
     end
 
     it 'attempts to call attribute writer methods raises NameError' do


### PR DESCRIPTION
Increases consistency as mutations on value objects should be created via #with(mutations).
