### PR TITLE
Raise more readable error message

### DIFF
--- a/lib/virtus/instance_methods.rb
+++ b/lib/virtus/instance_methods.rb
@@ -191,7 +191,14 @@ module Virtus
     #
     # @api private
     def set_attributes(attributes)
-      ::Hash.try_convert(attributes).each do |name, value|
+      hash = ::Hash.try_convert(attributes)
+
+      if hash.nil?
+        raise NoMethodError,
+          "Expected #{attributes.inspect} to respond to #to_hash"
+      end
+
+      hash.each do |name, value|
         set_attribute(name, value) if allowed_writer_methods.include?("#{name}=")
       end
     end

--- a/spec/unit/virtus/instance_methods/attributes_spec.rb
+++ b/spec/unit/virtus/instance_methods/attributes_spec.rb
@@ -131,7 +131,9 @@ describe Virtus::InstanceMethods do
       let(:attribute_values) { '' }
 
       it 'raises an exception' do
-        expect { subject }.to raise_error(NoMethodError)
+        expect {
+          subject
+        }.to raise_error(NoMethodError, 'Expected "" to respond to #to_hash')
       end
     end
   end


### PR DESCRIPTION
```
class User
  include Virtus
  attribute :adderss, Address
end
```

When I accidentally set a wrong attribute to the user address `User.new.address = Object.new`, then I'll get an error `undefined method`each' for nil:NilClass`. This doesn't tell much about what was wrong. I tried to make it a bit better with this pull request.
