### PR TITLE
Fix a test that failed when rspec 2 was used

### DIFF
--- a/spec/unit/virtus/instance_methods/initialize_spec.rb
+++ b/spec/unit/virtus/instance_methods/initialize_spec.rb
@@ -25,16 +25,22 @@ describe Virtus::InstanceMethods, '#initialize' do
   end
 
   context 'with an argument that responds to #to_hash' do
-    subject { described_class.new(:name => name) }
+    subject { described_class.new(attributes) }
 
-    let(:name) { stub('name') }
+    let(:attributes) do
+      Class.new do
+        def to_hash
+          {:name => 'John'}
+        end
+      end.new
+    end
 
     it 'sets attributes' do
-      subject.name.should be(name)
+      subject.name.should == 'John'
     end
   end
 
-  context' with an argument that does not respond to #to_hash' do
+  context 'with an argument that does not respond to #to_hash' do
     subject { described_class.new(Object.new) }
 
     specify { expect { subject }.to raise_error(NoMethodError) }


### PR DESCRIPTION
RSpec1: `spec spec` => Everything OK
RSpec2: `rspec spec` =>

```
  1) Virtus::InstanceMethods#initialize with an argument that responds to #to_hash sets attributes
     Failure/Error: subject.name.should be(name)

       expected #<RSpec::Mocks::Mock:18872480> => #<RSpec::Mocks::Mock:0x11ff8a0 @name="name">
            got #<String:18867120> => "#[RSpec::Mocks::Mock:0x11ff8a0 @name=\"name\"]"

       Compared using equal?, which compares object identity,
       but expected and actual are not the same object. Use
       'actual.should eq(expected)' if you don't care about
       object identity in this example.


       Diff:
       @@ -1,2 +1,2 @@
       -#<RSpec::Mocks::Mock:0x11ff8a0 @name="name">
       +"#[RSpec::Mocks::Mock:0x11ff8a0 @name=\"name\"]"
```

I wasn't 100% sure what was exactly tested here. I tried to change it to as close to the test name as possible. Now it passes with both rspec versions. 
