### PR TITLE
use equal instead of be for boolean coercion specs

### DIFF
--- a/spec/unit/virtus/coercion/string/class_methods/to_boolean_spec.rb
+++ b/spec/unit/virtus/coercion/string/class_methods/to_boolean_spec.rb
@@ -9,7 +9,7 @@ describe Virtus::Coercion::String, '.to_boolean' do
     context "with #{value.inspect}" do
       let(:string) { value }
 
-      it { should be(true) }
+      it { should equal(true) }
     end
   end
 
@@ -17,7 +17,7 @@ describe Virtus::Coercion::String, '.to_boolean' do
     context "with #{value.inspect}" do
       let(:string) { value }
 
-      it { should be(false) }
+      it { should equal(false) }
     end
   end
 


### PR DESCRIPTION
While investigating an open issue[1], I found myself wondering if the
`be(true)` and `be(false)` assertions were actually checking that we had
the explicit `true` and `false` values we wanted, versus just checking
Ruby truthiness, as in RSpec's `be_true` and `be_false`

In fact, the assertions do assert equality with `true` and `false`, and
this pull request does not change the behavior of the tests at all.  I
simply think using `equal` makes the behavior more obvious.

[1] https://github.com/solnic/virtus/issues/132
