### PR TITLE
Remove RSpec deprecation warnings

### DIFF
--- a/spec/unit/virtus/options/accept_options_spec.rb
+++ b/spec/unit/virtus/options/accept_options_spec.rb
@@ -1,21 +1,22 @@
 require 'spec_helper'
 
 describe Virtus::Options, '#accept_options' do
-  class Model
-    extend DescendantsTracker
-    extend Virtus::Options
+  let!(:object) do
+    Class.new do
+      extend DescendantsTracker
+      extend Virtus::Options
+    end
   end
-
-  let(:object)     { Model.dup         }
-  let(:descendant) { Class.new(object) }
-  let(:new_option) { :width            }
+  let!(:object_without_options) { object.dup }
+  let(:descendant)              { Class.new(object) }
+  let(:new_option)              { :width            }
 
   before do
     object.accept_options(new_option)
   end
 
   it 'does not have accepted options by default' do
-    Model.accepted_options.should_not include(new_option)
+    object_without_options.accepted_options.should_not include(new_option)
   end
 
   it 'sets new accepted options on itself' do


### PR DESCRIPTION
There is a deprecation warning in RSpec about calling objects defined in
`let` and `subject` blocks inside a `before(:all)` block. This PR knocks
that out by getting a fresh version of the model (by duping the class)
for each spec example. This is so that we can check that the accepted
options are set properly by default (the reason that there were
expectations in the `before(:all)` block before).

This also eliminates two unnecessary specs. Before, it was being
verified that both the model and its descendant were responding to a
message that was being sent to the model in a before hook.

Testing that the model responds to it is unnecessary because if it
doesn't it'll fail when it's called. Testing that a subclass responds
to a method defined in a superclass is testing that Ruby is actually an
object-oriented language. :-)
