### PR TITLE
Added an example using Boolean in a module

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,11 +126,17 @@ module Age
   attribute :age, Integer
 end
 
-class User
-  include Name, Age
+module Admin
+  include Virtus
+
+  attribute :admin, Virtus::Attribute::Boolean
 end
 
-user = User.new(:name => 'John', :age => '30')
+class User
+  include Name, Age, Admin
+end
+
+user = User.new(:name => 'John', :age => '30', :admin => true)
 ```
 
 ### Dynamically Extending Instances


### PR DESCRIPTION
Ran into a namespacing issue using virtus in a module:

``` ruby
module Admin
  include Virtus

  attribute :admin, Boolean
end
```

Including that module in a class would give ``const_missing': uninitialized constant Boolean (NameError)`

However, spelling it out as `Virtus::Attribute::Boolean` resolved the error
