### PR TITLE
Exposes accessor options

### DIFF
--- a/lib/virtus/attribute/accessor_method.rb
+++ b/lib/virtus/attribute/accessor_method.rb
@@ -36,6 +36,13 @@ module Virtus
       # @api private
       attr_reader :instance_variable_name
 
+      # Return options
+      #
+      # @return [Hash]
+      #
+      # @api private
+      attr_reader :options
+
       # Initialize accessor method instance
       #
       # @param [#to_sym] name
@@ -47,6 +54,7 @@ module Virtus
       # @api private
       def initialize(name, options = {})
         @name                   = name.to_sym
+        @options                = options
         @visibility             = options.fetch(:visibility, :public)
         @instance_variable_name = "@#{name}".to_sym
       end

--- a/spec/unit/virtus/attribute/writer/initialize_spec.rb
+++ b/spec/unit/virtus/attribute/writer/initialize_spec.rb
@@ -11,6 +11,7 @@ describe Virtus::Attribute::Writer, '#initialize' do
     its(:name)                   { should be(:test=) }
     its(:visibility)             { should be(:public) }
     its(:instance_variable_name) { should be(:@test) }
+    its(:options)                { should be_a(Hash) }
     its(:primitive)              { should be(Object) }
     its(:default_value)          { should be_instance_of(Virtus::Attribute::DefaultValue) }
   end
@@ -20,6 +21,7 @@ describe Virtus::Attribute::Writer, '#initialize' do
 
     its(:name)          { should be(:test=) }
     its(:visibility)    { should be(:private) }
+    its(:options)       { should == options }
     its(:primitive)     { should be(String) }
     its(:default_value) { should be_instance_of(Virtus::Attribute::DefaultValue::FromClonable) }
   end


### PR DESCRIPTION
Exposes options so that it can be used for say reconstructing attributes as proposed here: #175.
