### PR TITLE
Call super's initializer

### DIFF
--- a/lib/virtus/instance_methods.rb
+++ b/lib/virtus/instance_methods.rb
@@ -14,6 +14,10 @@ module Virtus
     def initialize(attributes = nil)
       attribute_set.set(self, attributes) if attributes
       set_default_attributes
+
+       # Our ancestor will often be Object, in which case we can't pass along
+       # the attributes since Object#initialize takes no arguments.
+      super()
     end
 
     # Returns a value of the attribute with the given name

--- a/spec/unit/virtus/instance_methods/initialize_spec.rb
+++ b/spec/unit/virtus/instance_methods/initialize_spec.rb
@@ -50,4 +50,23 @@ describe Virtus::InstanceMethods, '#initialize' do
 
     specify { expect { subject }.to raise_error(NoMethodError) }
   end
+
+  context 'when virtus is included in a module' do
+    let(:described_class) do
+      described_module = Module.new do
+        include Virtus
+        attr_reader :module_initializer_ran
+        def initialize(*args)
+          @module_initializer_ran = true
+        end
+      end
+      Class.new do
+        include described_module
+      end
+    end
+
+    it 'runs the superclass initializer' do
+      expect(subject.module_initializer_ran).to eql(true)
+    end
+  end
 end


### PR DESCRIPTION
If Virtus is included in a module, that module might want to add additional initialization, but without a call to super it can't.

It might be I added tests in the wrong places. If that or anything else is wrong, please let me know.
### Example use case:

``` ruby
module OurGem
  include Virtus
  def initialize(*args)
    perform_authorization_check
  end
end
```
### Caveats

I'm not too happy about explicitly expecting that no arguments are expected for `super`. However, if Virtus is included in a simple class with no (explicit) ancestor the ancestor will be Object, whose `#initialize` takes no arguments. So without the parentheses after `super()` the most basic use case would fail. This does however mean that the user still can't have:

``` ruby
class Supr
  def initialize(attributes = {})
    # do stuff with the initial attributes hash
  end
end

class Child
  include Virtus
end
```

I don't know if it's worth muddying up the code with arity checks. If there's an elegant solution, I'd love to hear it.
