### PR TITLE
Allow declaring attribute without type in Virtus.model

### DIFF
--- a/lib/virtus/module_builder.rb
+++ b/lib/virtus/module_builder.rb
@@ -106,7 +106,7 @@ module Virtus
     def attribute_method(configuration)
       module_options = self.module_options
 
-      lambda do |name, type, options = {}|
+      lambda do |name, type = Object, options = {}|
         super(name, type, module_options.merge(options))
       end
     end

--- a/spec/unit/virtus/attribute_spec.rb
+++ b/spec/unit/virtus/attribute_spec.rb
@@ -224,5 +224,12 @@ describe Virtus, '#attribute' do
       subject.test = :foo
       expect(subject.test).to be(:foo)
     end
+
+    it 'allows specifying attribute without type' do
+      model.attribute(:name)
+      expect(model.attribute_set[:name]).to be_instance_of(Virtus::Attribute)
+    end
+
+
   end
 end


### PR DESCRIPTION
This allows declaring attributes without a type using the new Virtus.model inclusion syntax, as mentioned in #193
