### PR TITLE
Embedded values are not coerced

### DIFF
--- a/spec/integration/embedded_value_spec.rb
+++ b/spec/integration/embedded_value_spec.rb
@@ -4,7 +4,7 @@ describe 'embedded values' do
   before do
     module Examples
       class City
-        include Virtus
+        include Virtus.model
 
         attribute :name, String
       end


### PR DESCRIPTION
I've tweaked an integration spec so it fails, to demonstrate the problem.  No solution in this PR, just a failing spec for a bug report.

Embedded attributes fail to get coerced when the _embedded_ model is created using `include Virtus.model`, rather than `include Virtus`
