### PR TITLE
failing spec for nested coercions

### DIFF
--- a/spec/integration/nested_coercions_spec.rb
+++ b/spec/integration/nested_coercions_spec.rb
@@ -1,0 +1,37 @@
+require 'virtus'
+
+
+describe "nested" do
+  class EmailAddress
+    include Virtus.value_object
+    values do
+      attribute :address, String, :coercer => lambda{|add| add.downcase }
+    end
+  end
+
+  def EmailAddress(string)
+    EmailAddress.new :address => string
+  end
+
+  class User
+    include Virtus.model
+    attribute :email, EmailAddress, :coercer => lambda {|add| new_address(add) }
+  end
+
+  let(:doe) { EmailAddress.new(:address => "john.doe@example.com") }
+
+  it "casts an email address" do
+    expect(EmailAddress("John.Doe@example.com")).to eq doe
+  end
+
+  it "accepts an email hash" do
+    user = User.new :email => { :address => "john.doe@example.com" }
+    expect(user.email).to eq doe
+  end
+
+  it "coreces an embedded string" do
+    user = User.new :email => "john.doe@example.com"
+    expect(user.email).to eq doe
+  end
+
+end


### PR DESCRIPTION
One more, and this may be intentional, or a regression, I'm not sure; failing spec attached to demonstrate

In beta0, I was able to define an explicit lambda for a coercion, though I don't find that obviously mentioned in the readme anywhere.  There are a couple of cases where I set things  up to convert a flat string value to a value object, as in the simplified EmailAddress example in this PR.  It seems like a specific coercer is recognized for flat attributes, but is no longer respected for embedded attribute types.

Either way, the documentation of both Virtus and Coercer is somewhat unclear about how I might go about building a coercion for a non-core value, like EmailAddress.

Thanks!
