### PR TITLE
re-introduce `ValueObject#with` which was removed with 6ea32ed.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* [feature] re-introduce `ValueObject#with`, which was removed in the past (senny)
+
 # v1.0.0 2013-10-16
 
 This release no longer works with Ruby 1.8.7.

--- a/lib/virtus/value_object.rb
+++ b/lib/virtus/value_object.rb
@@ -62,6 +62,22 @@ module Virtus
       end
       alias dup clone
 
+      # Create a new ValueObject by combining the passed attribute hash with
+      # the instances attributes.
+      #
+      # @example
+      #
+      #   number = PhoneNumber.new(kind: "mobile", number: "123-456-78-90")
+      #   number.with(number: "987-654-32-10")
+      #   # => #<PhoneNumber kind="mobile" number="987-654-32-10">
+      #
+      # @return [Object]
+      #
+      # @api public
+      def with(attribute_updates)
+        self.class.new(attribute_set.get(self).merge(attribute_updates))
+      end
+
     end
 
     module AllowedWriterMethods

--- a/spec/unit/virtus/value_object_spec.rb
+++ b/spec/unit/virtus/value_object_spec.rb
@@ -35,6 +35,12 @@ describe Virtus::ValueObject do
         %(#<Model #{attributes.map { |k, v| "#{k}=#{v.inspect}" }.join(' ')}>)
       )
     end
+
+    it 'allows to construct new values using #with' do
+      new_instance = subject.with(:name => "John Doe")
+      expect(new_instance.id).to eql(subject.id)
+      expect(new_instance.name).to eql("John Doe")
+    end
   end
 
   share_examples_for 'a valid value object with mass-assignment turned on' do


### PR DESCRIPTION
The `#with` method was part of the public interface and used in several of my applications. If there is no hard reason against it, I'd like to add it back.

Some implementation notes:
- It uses `attribute_set.get(self)` in the hope to also reuse not publicly accessible attributes.
- the test-case is not optimal but as I added it to the `shared_examples` it was difficult to compare the whole object. There are tests that add more attributes later on.
- I used `[Object]` as the return type as I was not sure if there is a way to describe "a new instance of the same class".
