### PR TITLE
Performance fix for AttributeSet#each.

### DIFF
--- a/lib/virtus/attribute_set.rb
+++ b/lib/virtus/attribute_set.rb
@@ -43,7 +43,7 @@ module Virtus
     # @api public
     def each
       return to_enum unless block_given?
-      @index.values.uniq.each { |attribute| yield attribute }
+      @index.each { |name, attribute| yield attribute if name.kind_of?(Symbol) }
       self
     end
 


### PR DESCRIPTION
Using uniq on attributes array is slow, because it must compare
attributes to each other. This change makes initialization of a new
object with Virtus attributes at least 3 times faster (depends on a number of attributes)

Here's benchmark:

```
Rehearsal --------------------------------------------
old each   0.970000   0.000000   0.970000 (  0.974661)
new each   0.360000   0.000000   0.360000 (  0.362813)
----------------------------------- total: 1.330000sec

               user     system      total        real
old each   0.980000   0.000000   0.980000 (  0.978254)
new each   0.380000   0.000000   0.380000 (  0.372626)

```

``` ruby
require 'virtus'
require 'date'
require 'benchmark'

class Virtus::AttributeSet<Module
  alias_method :orig_each, :each
  def new_each
    return to_enum unless block_given?
    @index.keys.select{|x| Symbol === x}.each do |name|
      yield @index[name]
    end
    self
  end
  def dan_each
    return to_enum unless block_given?
    @index.each { |name, attribute| yield attribute if name.kind_of?(Symbol) }
    self
  end
end


class VirtusTest
  include Virtus.model
  attribute :id, Integer
  attribute :text, String
  attribute :size, Float
  attribute :number, Integer
  attribute :date, Date
end


TESTS = 100_000
Benchmark.bmbm do |x|
  x.report("old each") do
    class Virtus::AttributeSet<Module; alias_method :each, :orig_each; end
    TESTS.times{VirtusTest.new(id: 1, text: 'test', size: 25, number: 9999, date: '2013-10-23')}
  end
  x.report("Antti") do
    class Virtus::AttributeSet<Module; alias_method :each, :new_each; end
    TESTS.times{VirtusTest.new(id: 1, text: 'test', size: 25, number: 9999, date: '2013-10-23')}
  end
  x.report("dkubb") do
    class Virtus::AttributeSet<Module; alias_method :each, :dan_each; end
    TESTS.times{VirtusTest.new(id: 1, text: 'test', size: 25, number: 9999, date: '2013-10-23')}
  end
  class Virtus::AttributeSet<Module; alias_method :each, :orig_each; end
end
```
