### PR TITLE
Typo in ivar assignment in CoercionError

### DIFF
--- a/lib/virtus.rb
+++ b/lib/virtus.rb
@@ -14,7 +14,7 @@ module Virtus
     attr_reader :output, :primitive
 
     def initialize(output, primitive)
-      @output, @private = output, primitive
+      @output, @primitive = output, primitive
       super("Failed to coerce #{output.inspect} into #{primitive.inspect}")
     end
   end


### PR DESCRIPTION
The ivar `@private` is assigned from the argument `primitive`. This seems to be a typo due to autocompletion.
