### PR TITLE
Improve value_object's #hash uniformity

### DIFF
--- a/lib/virtus/support/equalizer.rb
+++ b/lib/virtus/support/equalizer.rb
@@ -65,7 +65,7 @@ module Virtus
     def define_hash_method
       keys = @keys
       define_method(:hash) do
-        keys.map { |key| send(key).hash }.reduce(self.class.hash, :^)
+        keys.map { |key| send(key) }.push(self.class).hash
       end
     end
 


### PR DESCRIPTION
Array#hash is designed to be uniform, unlike reduce(:^).hash

``` ruby
class Point
  include Virtus.value_object
  values do
     attribute :x, Integer
     attribute :y, Integer
  end
end

Point.new(x: 1, y: 1).hash == Point.new.hash # was true
Point.new(x: 1).hash == Point.new(y: 1).hash # was true
```
