### PR TITLE
Options#define_option_method: don’t clobber `false` ivars

### DIFF
--- a/lib/virtus/support/options.rb
+++ b/lib/virtus/support/options.rb
@@ -61,7 +61,7 @@ module Virtus
     def define_option_method(option)
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def self.#{option}(value = Undefined)           # def self.primitive(value = Undefined)
-          @#{option} ||= nil                            #   @primitive ||= nil
+          @#{option} = nil unless defined?(@#{option})  #   @primitive = nil unless defined?(@primitive)
           return @#{option} if value.equal?(Undefined)  #   return @primitive if value.equal?(Undefined)
           @#{option} = value                            #   @primitive = value
           self                                          #   self


### PR DESCRIPTION
This is a follow-up to #255 – I just realised the previous approach would clobber `false` ivars (by reassigning them to `nil`). Apologies!
