### PR TITLE
Fixed attributes with Range type

### DIFF
--- a/lib/virtus/attribute/builder.rb
+++ b/lib/virtus/attribute/builder.rb
@@ -107,7 +107,7 @@ module Virtus
               determine_type(klass.primitive)
             elsif EmbeddedValue.handles?(klass)
               EmbeddedValue
-            elsif klass < Enumerable
+            elsif klass < Enumerable && !(klass <= Range)
               Collection
             end
         end


### PR DESCRIPTION
Range is an Enumerable, but not a "collection". It doesn't have an empty constructor and it doesn't have a '<'-operator. 

This is sort of a quick-fix. I didn't write any tests, since that would only test the code, as there's no reason to expect a Range to be treated as a collection. 

I believe a better solution would be to whitelist the likely classes and to add an option to make other classes be treated as a collection, with a clear description of how a collection for Vitus needs to quack. But that would not be backward compatible, so is something for 2.0.
