### PR TITLE
Expose the name of the attribute failing coercion

### DIFF
--- a/lib/virtus.rb
+++ b/lib/virtus.rb
@@ -11,11 +11,31 @@ module Virtus
   Undefined = Object.new.freeze
 
   class CoercionError < StandardError
-    attr_reader :output, :primitive
+    attr_reader :output, :attribute
 
-    def initialize(output, primitive)
-      @output, @primitive = output, primitive
-      super("Failed to coerce #{output.inspect} into #{primitive.inspect}")
+    def initialize(output, attribute)
+      @output, @attribute = output, attribute
+      super(build_message)
+    end
+
+    def build_message
+      if attribute_name?
+        "Failed to coerce attribute `#{attribute_name}' from #{output.inspect} into #{target_type}"
+      else
+        "Failed to coerce #{output.inspect} into #{target_type}"
+      end
+    end
+
+    def attribute_name
+      attribute.options[:name]
+    end
+
+    def attribute_name?
+      attribute_name ? true : false
+    end
+
+    def target_type
+      attribute.primitive.inspect
     end
   end
 

--- a/lib/virtus/attribute/strict.rb
+++ b/lib/virtus/attribute/strict.rb
@@ -16,7 +16,7 @@ module Virtus
         if value_coerced?(output) || !required? && output.nil?
           output
         else
-          raise CoercionError.new(output, primitive)
+          raise CoercionError.new(output, self)
         end
       end
 

--- a/spec/integration/required_attributes_spec.rb
+++ b/spec/integration/required_attributes_spec.rb
@@ -13,7 +13,7 @@ describe 'Using required attributes' do
   end
 
   it 'raises coercion error when required attribute is nil' do
-    expect { Examples::User.new(:name => nil) }.to raise_error(Virtus::CoercionError)
+    expect { Examples::User.new(:name => nil) }.to raise_error(Virtus::CoercionError, "Failed to coerce attribute `name' from nil into String")
   end
 
   it 'does not raise coercion error when not required attribute is nil' do


### PR DESCRIPTION
Resolves #254

Currently, when you `include Virtus.model(strict: true)`, and you fail to supply any of the attributes, the exception message doesn't let you know _which_ attribute was missing. This can lead to painful debugging sessions, particularly when a model embeds other models.

This pull request attempts to address that by providing visibility into the name of the attribute that could not be coerced. Since not all `Virtus::Attribute` instances actually _have_ a name, we fall back to the old message when one isn't present.
