### PR TITLE
Update specs to RSpec 2.14.8 (Updated)

### DIFF
--- a/spec/integration/custom_attributes_spec.rb
+++ b/spec/integration/custom_attributes_spec.rb
@@ -31,12 +31,12 @@ describe 'custom attributes' do
   specify 'allows you to define custom attributes' do
     regexp = /awesome/
     subject.expression = regexp
-    subject.expression.should == regexp
+    expect(subject.expression).to eq(regexp)
   end
 
   specify 'allows you to define coercion methods' do
     subject.scream = 'welcome'
-    subject.scream.should == 'WELCOME'
+    expect(subject.scream).to eq('WELCOME')
   end
 
 end

--- a/spec/integration/custom_collection_attributes_spec.rb
+++ b/spec/integration/custom_collection_attributes_spec.rb
@@ -36,7 +36,7 @@ describe 'custom collection attributes' do
   shared_examples_for 'a collection' do
     it 'can be used as Virtus attributes' do
       attribute = Examples::Library.attribute_set[:books]
-      attribute.should be_kind_of(Examples::BookCollectionAttribute)
+      expect(attribute).to be_kind_of(Examples::BookCollectionAttribute)
     end
 
     it 'defaults to an empty collection' do
@@ -55,18 +55,18 @@ describe 'custom collection attributes' do
 
     it 'coerces an array of attribute hashes' do
       library.books = [{ :title => 'Foo' }]
-      books.should be_kind_of(Examples::BookCollection)
+      expect(books).to be_kind_of(Examples::BookCollection)
     end
 
     it 'coerces its members' do
       library.books = [{ :title => 'Foo' }]
-      books.count.should == 1
-      books.first.should be_kind_of(Examples::Book)
+      expect(books.count).to eq(1)
+      expect(books.first).to be_kind_of(Examples::Book)
     end
 
     def books_should_be_an_empty_collection
-      books.should be_kind_of(Examples::BookCollection)
-      books.count.should == 0
+      expect(books).to be_kind_of(Examples::BookCollection)
+      expect(books.count).to eq(0)
     end
   end
 

--- a/spec/integration/default_values_spec.rb
+++ b/spec/integration/default_values_spec.rb
@@ -35,21 +35,21 @@ describe "default values" do
   subject { Examples::Page.new }
 
   specify 'without a default the value is nil' do
-    subject.title.should be_nil
+    expect(subject.title).to be_nil
   end
 
   specify 'can be supplied with the :default option' do
-    subject.view_count.should == 0
+    expect(subject.view_count).to eq(0)
   end
 
   specify "you can pass a 'callable-object' to the :default option" do
     subject.title = 'Example Blog Post'
-    subject.slug.should == 'example-blog-post'
+    expect(subject.slug).to eq('example-blog-post')
   end
 
   specify 'you can set defaults for private attributes' do
     subject.title = 'Top Secret'
-    subject.editor_title.should == 'UNPUBLISHED: Top Secret'
+    expect(subject.editor_title).to eq('UNPUBLISHED: Top Secret')
   end
 
   specify 'you can reset attribute to its default' do
@@ -63,25 +63,25 @@ describe "default values" do
     it 'does not duplicate the ValueObject' do
       page1 = Examples::Page.new
       page2 = Examples::Page.new
-      page1.reference.should equal(page2.reference)
+      expect(page1.reference).to equal(page2.reference)
     end
   end
 
   context 'an Array' do
     specify 'without a default the value is an empty Array' do
-      subject.revisions.should eql([])
+      expect(subject.revisions).to eql([])
     end
   end
 
   context 'a Hash' do
     specify 'without a default the value is an empty Hash' do
-      subject.index.should eql({})
+      expect(subject.index).to eql({})
     end
   end
 
   context 'a Set' do
     specify 'without a default the value is an empty Set' do
-      subject.authors.should eql(Set.new)
+      expect(subject.authors).to eql(Set.new)
     end
   end
 end

--- a/spec/integration/defining_attributes_spec.rb
+++ b/spec/integration/defining_attributes_spec.rb
@@ -23,19 +23,19 @@ describe "virtus attribute definitions" do
 
   specify 'virtus creates accessor methods' do
     subject.name = 'Peter'
-    subject.name.should == 'Peter'
+    expect(subject.name).to eq('Peter')
   end
 
   specify 'the constructor accepts a hash for mass-assignment' do
     john = Examples::Person.new(:name => 'John', :age => 13)
-    john.name.should == 'John'
-    john.age.should == 13
+    expect(john.name).to eq('John')
+    expect(john.age).to eq(13)
   end
 
   specify 'Boolean attributes have a getter with questionmark' do
-    subject.doctor?.should be_false
+    expect(subject.doctor?).to be_false
     subject.doctor = true
-    subject.doctor?.should be_true
+    expect(subject.doctor?).to be_true
   end
 
   context 'with attributes' do
@@ -43,26 +43,26 @@ describe "virtus attribute definitions" do
     subject { Examples::Person.new(attributes) }
 
     specify "#attributes returns the object's attributes as a hash" do
-      subject.attributes.should == attributes
+      expect(subject.attributes).to eq(attributes)
     end
 
     specify "#to_hash returns the object's attributes as a hash" do
-      subject.to_hash.should == attributes
+      expect(subject.to_hash).to eq(attributes)
     end
   end
 
   context 'inheritance' do
     specify 'inherits all the attributes from the base class' do
       fred = Examples::Manager.new(:name => 'Fred', :age => 29)
-      fred.name.should == 'Fred'
-      fred.age.should == 29
+      expect(fred.name).to eq('Fred')
+      expect(fred.age).to eq(29)
     end
 
     specify 'lets you add attributes to the base class at runtime' do
       frank = Examples::Manager.new(:name => 'Frank')
       Examples::Person.attribute :just_added, String
       frank.just_added = 'it works!'
-      frank.just_added.should == 'it works!'
+      expect(frank.just_added).to eq('it works!')
     end
 
     specify 'lets you add attributes to the subclass at runtime' do
@@ -71,9 +71,9 @@ describe "virtus attribute definitions" do
       Examples::Manager.attribute :just_added, String
 
       manager_frank.just_added = 'awesome!'
-      manager_frank.just_added.should == 'awesome!'
-      person_jack.should_not respond_to(:just_added)
-      person_jack.should_not respond_to(:just_added=)
+      expect(manager_frank.just_added).to eq('awesome!')
+      expect(person_jack).not_to respond_to(:just_added)
+      expect(person_jack).not_to respond_to(:just_added=)
     end
   end
 end

--- a/spec/integration/embedded_value_spec.rb
+++ b/spec/integration/embedded_value_spec.rb
@@ -33,18 +33,18 @@ describe 'embedded values' do
   end
 
   specify '#attributes returns instances of the embedded values' do
-    subject.attributes.should == {
+    expect(subject.attributes).to eq({
       :name => 'the guy',
       :address => subject.address
-    }
+    })
   end
 
   specify 'allows you to pass a hash for the embedded value' do
     user = Examples::User.new
     user.address = address_attributes
-    user.address.street.should == 'Street 1/2'
-    user.address.zipcode.should == '12345'
-    user.address.city.name.should == 'NYC'
+    expect(user.address.street).to eq('Street 1/2')
+    expect(user.address.zipcode).to eq('12345')
+    expect(user.address.city.name).to eq('NYC')
   end
 
 end

--- a/spec/integration/extending_objects_spec.rb
+++ b/spec/integration/extending_objects_spec.rb
@@ -21,15 +21,15 @@ describe 'I can extend objects' do
     admin.name = 'John'
     admin.age  = 29
 
-    admin.name.should eql('John')
-    admin.age.should eql(29)
+    expect(admin.name).to eql('John')
+    expect(admin.age).to eql(29)
 
-    admin.attributes.should eql(attributes)
+    expect(admin.attributes).to eql(attributes)
 
     new_attributes   = { :name => 'Jane', :age => 28 }
     admin.attributes = new_attributes
 
-    admin.name.should eql('Jane')
-    admin.age.should eql(28)
+    expect(admin.name).to eql('Jane')
+    expect(admin.age).to eql(28)
   end
 end

--- a/spec/integration/hash_attributes_coercion_spec.rb
+++ b/spec/integration/hash_attributes_coercion_spec.rb
@@ -23,28 +23,32 @@ describe Package do
   describe '#dimensions' do
     subject { dimensions }
 
-    it { should have(3).keys }
+    it 'has 3 keys' do
+      expect(subject.keys.size).to eq(3)
+    end
     it { should have_key :width  }
     it { should have_key :height }
     it { should have_key :length }
 
     it 'should be coerced to [Symbol => Float] format' do
-      dimensions[:width].should  be_eql(2.2)
-      dimensions[:height].should be_eql(2.0)
-      dimensions[:length].should be_eql(4.5)
+      expect(dimensions[:width]).to  be_eql(2.2)
+      expect(dimensions[:height]).to be_eql(2.0)
+      expect(dimensions[:length]).to be_eql(4.5)
     end
   end
 
   describe '#meta_info' do
     subject { meta_info }
 
-    it { should have(2).keys }
+    it 'has 2 keys' do
+      expect(subject.keys.size).to eq(2)
+    end
     it { should have_key 'from' }
     it { should have_key 'to'   }
 
     it 'should be coerced to [String => String] format' do
-      meta_info['from'].should == 'Me'
-      meta_info['to'].should == 'You'
+      expect(meta_info['from']).to eq('Me')
+      expect(meta_info['to']).to eq('You')
     end
   end
 end

--- a/spec/integration/mass_assignment_with_accessors_spec.rb
+++ b/spec/integration/mass_assignment_with_accessors_spec.rb
@@ -28,17 +28,17 @@ describe "mass assignment with accessors" do
   subject { Examples::Product.new(:categories => ['Office', 'Printers'], :_id => 100) }
 
   specify 'works uppon instantiation' do
-    subject.category.should == 'Office'
-    subject.subcategory.should == 'Printers'
+    expect(subject.category).to eq('Office')
+    expect(subject.subcategory).to eq('Printers')
   end
 
   specify 'can be set with #attributes=' do
     subject.attributes = {:categories => ['Home', 'Furniture']}
-    subject.category.should == 'Home'
-    subject.subcategory.should == 'Furniture'
+    expect(subject.category).to eq('Home')
+    expect(subject.subcategory).to eq('Furniture')
   end
 
   specify 'respects accessor visibility' do
-    subject.id.should_not == 100
+    expect(subject.id).not_to eq(100)
   end
 end

--- a/spec/integration/overriding_virtus_spec.rb
+++ b/spec/integration/overriding_virtus_spec.rb
@@ -22,11 +22,11 @@ describe 'overriding virtus behavior' do
 
   describe 'overriding an attribute getter' do
     specify 'calls the defined getter' do
-      Examples::Article.new.title.should == '<unknown>'
+      expect(Examples::Article.new.title).to eq('<unknown>')
     end
 
     specify 'super can be used to access the getter defined by virtus' do
-      Examples::Article.new(:title => 'example article').title.should == 'example article'
+      expect(Examples::Article.new(:title => 'example article').title).to eq('example article')
     end
   end
 
@@ -34,13 +34,13 @@ describe 'overriding virtus behavior' do
     specify 'calls the defined setter' do
       article = Examples::Article.new(:title => "can't be changed")
       article.title = 'this will never be assigned'
-      article.title.should == "can't be changed"
+      expect(article.title).to eq("can't be changed")
     end
 
     specify 'super can be used to access the setter defined by virtus' do
       article = Examples::Article.new(:title => 'example article')
       article.title = 'my new title'
-      article.title.should == 'my new title'
+      expect(article.title).to eq('my new title')
     end
   end
 end

--- a/spec/integration/struct_as_embedded_value_spec.rb
+++ b/spec/integration/struct_as_embedded_value_spec.rb
@@ -19,10 +19,10 @@ describe 'Using Struct as an embedded value attribute' do
   end
 
   specify 'initialize a struct object with correct attributes' do
-    subject.top_left.x.should be(3)
-    subject.top_left.y.should be(5)
+    expect(subject.top_left.x).to be(3)
+    expect(subject.top_left.y).to be(5)
 
-    subject.bottom_right.x.should be(8)
-    subject.bottom_right.y.should be(7)
+    expect(subject.bottom_right.x).to be(8)
+    expect(subject.bottom_right.y).to be(7)
   end
 end

--- a/spec/integration/using_modules_spec.rb
+++ b/spec/integration/using_modules_spec.rb
@@ -33,15 +33,15 @@ describe 'I can define attributes within a module' do
   end
 
   specify 'including a module with attributes into a class' do
-    Examples::User.attribute_set[:name].should be_instance_of(Virtus::Attribute)
-    Examples::User.attribute_set[:gamer].should be_instance_of(Virtus::Attribute::Boolean)
+    expect(Examples::User.attribute_set[:name]).to be_instance_of(Virtus::Attribute)
+    expect(Examples::User.attribute_set[:gamer]).to be_instance_of(Virtus::Attribute::Boolean)
 
-    Examples::Admin.attribute_set[:name].should be_instance_of(Virtus::Attribute)
-    Examples::Admin.attribute_set[:age].should be_instance_of(Virtus::Attribute)
+    expect(Examples::Admin.attribute_set[:name]).to be_instance_of(Virtus::Attribute)
+    expect(Examples::Admin.attribute_set[:age]).to be_instance_of(Virtus::Attribute)
 
     user = Examples::Admin.new(:name => 'Piotr', :age => 29)
-    user.name.should eql('Piotr')
-    user.age.should eql(29)
+    expect(user.name).to eql('Piotr')
+    expect(user.age).to eql(29)
   end
 
   specify 'including a module with attributes into an instance' do
@@ -49,7 +49,7 @@ describe 'I can define attributes within a module' do
     moderator.extend(Examples::Name, Examples::Age)
 
     moderator.attributes = { :name => 'John', :age => 21 }
-    moderator.name.should eql('John')
-    moderator.age.should eql(21)
+    expect(moderator.name).to eql('John')
+    expect(moderator.age).to eql(21)
   end
 end

--- a/spec/integration/value_object_with_custom_constructor_spec.rb
+++ b/spec/integration/value_object_with_custom_constructor_spec.rb
@@ -33,10 +33,10 @@ describe "Defining a ValueObject with a custom constructor" do
   end
 
   specify "initialize a value object attribute with correct attributes" do
-    subject.top_left.x.should be(3)
-    subject.top_left.y.should be(4)
+    expect(subject.top_left.x).to be(3)
+    expect(subject.top_left.y).to be(4)
 
-    subject.bottom_right.x.should be(5)
-    subject.bottom_right.y.should be(8)
+    expect(subject.bottom_right.x).to be(5)
+    expect(subject.bottom_right.y).to be(8)
   end
 end

--- a/spec/integration/virtus/instance_level_attributes_spec.rb
+++ b/spec/integration/virtus/instance_level_attributes_spec.rb
@@ -17,7 +17,7 @@ describe Virtus, 'instance level attributes' do
     it 'allows setting the attribute value on the instance' do
       attribute
       subject.name = 'foo'
-      subject.name.should eql('foo')
+      expect(subject.name).to eql('foo')
     end
   end
 end

--- a/spec/integration/virtus/value_object_spec.rb
+++ b/spec/integration/virtus/value_object_spec.rb
@@ -26,21 +26,21 @@ describe Virtus::ValueObject do
 
   describe 'initialization' do
     it 'sets the attribute values provided to Class.new' do
-      class_under_test.new(:latitude => 10000.001).latitude.should == 10000.001
-      subject.latitude.should eql(attribute_values[:latitude])
+      expect(class_under_test.new(:latitude => 10000.001).latitude).to eq(10000.001)
+      expect(subject.latitude).to eql(attribute_values[:latitude])
     end
   end
 
   describe 'writer visibility' do
     it 'attributes are configured for private writers' do
-      class_under_test.attribute_set[:latitude].public_reader?.should be(true)
-      class_under_test.attribute_set[:longitude].public_writer?.should be(false)
+      expect(class_under_test.attribute_set[:latitude].public_reader?).to be(true)
+      expect(class_under_test.attribute_set[:longitude].public_writer?).to be(false)
     end
 
     it 'writer methods are set to private' do
       private_methods = class_under_test.private_instance_methods
       private_methods.map! { |m| m.to_s }
-      private_methods.should include('latitude=', 'longitude=', 'attributes=')
+      expect(private_methods).to include('latitude=', 'longitude=', 'attributes=')
     end
 
     it 'attempts to call attribute writer methods raises NameError' do
@@ -52,48 +52,48 @@ describe Virtus::ValueObject do
   describe 'equality' do
     describe '#==' do
       it 'returns true for different objects with the same state' do
-        subject.should == instance_with_equal_state
+        expect(subject).to eq(instance_with_equal_state)
       end
 
       it 'returns false for different objects with different state' do
-        subject.should_not == instance_with_different_state
+        expect(subject).not_to eq(instance_with_different_state)
       end
     end
 
     describe '#eql?' do
       it 'returns true for different objects with the same state' do
-        subject.should eql(instance_with_equal_state)
+        expect(subject).to eql(instance_with_equal_state)
       end
 
       it 'returns false for different objects with different state' do
-        subject.should_not eql(instance_with_different_state)
+        expect(subject).not_to eql(instance_with_different_state)
       end
     end
 
     describe '#equal?' do
       it 'returns false for different objects with the same state' do
-        subject.should_not equal(instance_with_equal_state)
+        expect(subject).not_to equal(instance_with_equal_state)
       end
 
       it 'returns false for different objects with different state' do
-        subject.should_not equal(instance_with_different_state)
+        expect(subject).not_to equal(instance_with_different_state)
       end
     end
 
     describe '#hash' do
       it 'returns the same value for different objects with the same state' do
-        subject.hash.should eql(instance_with_equal_state.hash)
+        expect(subject.hash).to eql(instance_with_equal_state.hash)
       end
 
       it 'returns different values for different objects with different state' do
-        subject.hash.should_not eql(instance_with_different_state.hash)
+        expect(subject.hash).not_to eql(instance_with_different_state.hash)
       end
     end
   end
 
   describe '#inspect' do
     it 'includes the class name and attribute values' do
-      subject.inspect.should == '#<GeoLocation latitude=10.0 longitude=20.0>'
+      expect(subject.inspect).to eq('#<GeoLocation latitude=10.0 longitude=20.0>')
     end
   end
 end

--- a/spec/shared/freeze_method_behavior.rb
+++ b/spec/shared/freeze_method_behavior.rb
@@ -32,6 +32,6 @@ shared_examples_for 'a #freeze method' do
   its(:frozen?) { should be(true) }
 
   it 'allows to access attribute' do
-    subject.name.should eql('John')
+    expect(subject.name).to eql('John')
   end
 end

--- a/spec/unit/virtus/attribute_set/each_spec.rb
+++ b/spec/unit/virtus/attribute_set/each_spec.rb
@@ -14,7 +14,7 @@ describe Virtus::AttributeSet, '#each' do
     it { should be_instance_of(to_enum.class) }
 
     it 'yields the expected attributes' do
-      subject.to_a.should eql(object.to_a)
+      expect(subject.to_a).to eql(object.to_a)
     end
   end
 

--- a/spec/unit/virtus/attribute_set/element_reference_spec.rb
+++ b/spec/unit/virtus/attribute_set/element_reference_spec.rb
@@ -12,6 +12,6 @@ describe Virtus::AttributeSet, '#[]' do
   it { should equal(attribute) }
 
   it 'allows indexed access to attributes by the string representation of their name' do
-    object[name.to_s].should equal(attribute)
+    expect(object[name.to_s]).to equal(attribute)
   end
 end


### PR DESCRIPTION
This conversion is done by Transpec 1.13.1 with the following command:
    transpec --keep its
- 78 conversions
  from: obj.should
    to: expect(obj).to
- 35 conversions
  from: == expected
    to: eq(expected)
- 8 conversions
  from: obj.should_not
    to: expect(obj).not_to
- 2 conversions
  from: it { should have(n).keys }
    to: it 'has n keys' do expect(subject.keys.size).to eq(n) end
