### PR TITLE
Set InstanceMethods#to_h as an alias.

### DIFF
--- a/lib/virtus/instance_methods.rb
+++ b/lib/virtus/instance_methods.rb
@@ -42,6 +42,7 @@ module Virtus
         attribute_set.get(self)
       end
       alias_method :to_hash, :attributes
+      alias_method :to_h, :attributes
 
       # Mass-assign attribute values
       #

--- a/spec/integration/defining_attributes_spec.rb
+++ b/spec/integration/defining_attributes_spec.rb
@@ -49,6 +49,10 @@ describe "virtus attribute definitions" do
     specify "#to_hash returns the object's attributes as a hash" do
       subject.to_hash.should == attributes
     end
+
+    specify "#to_h returns the object's attributes as a hash" do
+      subject.to_h.should == attributes
+    end
   end
 
   context 'inheritance' do


### PR DESCRIPTION
ActiveRecord serializers require the to_h method. Without this PR, one must create a serializer like the following:

``` ruby
class UserPreferences
  include Virtus.model

  attribute :github, String
  attribute :twitter, String
  attribute :newsletter, Boolean

  alias_method :to_h, :to_hash

  def self.dump(preferences)
    preferences.to_h
  end

  def self.load(preferences)
    new(preferences)
  end
end
```

The to_h method used to work on the `include Virtus` era, but not anymore.
