### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Virtus
 [![Dependency Status](https://gemnasium.com/solnic/virtus.png)][gemnasium]
 [![Code Climate](https://codeclimate.com/github/solnic/virtus.png)][codeclimate]
 [![Coverage Status](https://coveralls.io/repos/solnic/virtus/badge.png?branch=master)][coveralls]
-[![Inline docs](http://inch-pages.github.io/github/solnic/virtus.png)][inchpages]
+[![Inline docs](http://inch-ci.org/github/solnic/virtus.png)][inchpages]
 
 [gem]: https://rubygems.org/gems/virtus
 [travis]: https://travis-ci.org/solnic/virtus
 [gemnasium]: https://gemnasium.com/solnic/virtus
 [codeclimate]: https://codeclimate.com/github/solnic/virtus
 [coveralls]: https://coveralls.io/r/solnic/virtus
-[inchpages]: http://inch-pages.github.io/github/solnic/virtus
+[inchpages]: http://inch-ci.org/github/solnic/virtus
 
 This is a partial extraction of the DataMapper [Property
 API](http://rubydoc.info/github/datamapper/dm-core/master/DataMapper/Property)


### PR DESCRIPTION
Hi there,

this patch updates the URL of the docs badge in your README. Inch's badges will be served from it's own CI service http://inch-ci.org in the future and I will slowly retire the old [Inch Pages project](http://inch-pages.github.io/). 

With the new service, people can [add projects straight from the homepage](http://inch-ci.org/) and also [configure a webhook to rebuild](http://inch-ci.org/howto/webhook) their badges auto-magically :star2:

I am so happy that Inch and Inch Pages were so well received in the community and that I am now able to keep [my promise](http://trivelop.de/2014/02/24/visibility-of-documentation/) to deliver a real, [open source](https://github.com/inch-ci) web service for the badges.

P.S. I have not written an announcement or anything for this, yet. **But**: Everybody who reads this is invited to add their projects to the site. Please help me find the last bugs, so I can start writing the "Introducing Inch CI" blog post :wink:
