### PR TITLE
Add handling of nil values for collection attributes

### DIFF
--- a/lib/virtus/attribute/collection.rb
+++ b/lib/virtus/attribute/collection.rb
@@ -70,8 +70,9 @@ module Virtus
       end
 
       # @api public
-      def coerce(*)
-        super.each_with_object(primitive.new) do |entry, collection|
+      def coerce(value)
+        return value unless super(value).respond_to?(:each_with_object)
+        super(value).each_with_object(primitive.new) do |entry, collection|
           collection << member_type.coerce(entry)
         end
       end

--- a/spec/unit/virtus/attribute/collection/coerce_spec.rb
+++ b/spec/unit/virtus/attribute/collection/coerce_spec.rb
@@ -50,4 +50,19 @@ describe Virtus::Attribute::Collection, '#coerce' do
       end
     end
   end
+
+  context 'when input is nil' do
+    let(:input) { nil }
+    fake(:coercer)     { Virtus::Attribute::Coercer }
+    fake(:member_type) { Virtus::Attribute }
+
+    let(:member_primitive) { Integer }
+    let(:object) {
+      described_class.build(Array[member_primitive], :coercer => coercer, :member_type => member_type)
+    }
+
+    it 'returns nil' do
+      expect(subject).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
A recent upgrade from Virtus 0.5.5 to 1.0.2 exposed in issue that had changed with nil handling and collection attributes.  We had code similar to this:

``` ruby
atttribute :email_lists, Array[Integer]
```

This worked fine if the value was set to nil which was a reasonable value.  After upgrading to 1.0.2 the unit tests where the value was set to nil blew up with the following error:

```
NoMethodError:
       undefined method `each_with_object' for nil:NilClass
```

It looks like an explicit check was removed from the coerce() method on Collection class quite a while ago as part of a larger refactoring.  This pull request fixes this issue with an explicit check.  I'm not sure if this is the desired behavior for Virtus, but it makes it more usable for us.
