### PR TITLE
Allow mixing in multiple Virtus.modules

### DIFF
--- a/lib/virtus/module_extensions.rb
+++ b/lib/virtus/module_extensions.rb
@@ -57,7 +57,9 @@ module Virtus
       super
 
       if Class === object
-        @inclusions.each { |mod| object.send(:include, mod) }
+        @inclusions.each do |mod|
+          object.send(:include, mod) unless object.ancestors.include?(mod)
+        end
         define_attributes(object)
       else
         object.extend(ModuleExtensions)

--- a/spec/unit/virtus/module_spec.rb
+++ b/spec/unit/virtus/module_spec.rb
@@ -114,4 +114,30 @@ describe Virtus, '.module' do
     end
   end
 
+  context 'as a peer to another module within a class' do
+    subject { Virtus.module }
+    let(:other)  { Module.new }
+
+    before do
+      other.send(:include, Virtus.module)
+      other.attribute :last_name, String, :default => 'Doe'
+      other.attribute :something_else
+      model.send(:include, mod)
+      model.send(:include, other)
+    end
+
+    it 'provides attributes for the model from both modules' do
+      expect(model.attribute_set[:name]).to be_kind_of(Virtus::Attribute)
+      expect(model.attribute_set[:something]).to be_kind_of(Virtus::Attribute)
+      expect(model.attribute_set[:last_name]).to be_kind_of(Virtus::Attribute)
+      expect(model.attribute_set[:something_else]).to be_kind_of(Virtus::Attribute)
+    end
+
+    it 'includes the attributes from both modules' do
+      expect(model.new.attributes.keys).to eq(
+        [:name, :something, :last_name, :something_else]
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
Known caveat: if one module wants constructors/coercions/mass-assignment but the other one doesn't, the one that _does_ want those features will win since it mixes in the module (this problem already exists though, so this patch doesn't make things any worse).

fixes #260
fixes #274
