### PR TITLE
Handle multiple modules mixed into another module

### DIFF
--- a/lib/virtus/module_extensions.rb
+++ b/lib/virtus/module_extensions.rb
@@ -15,7 +15,9 @@ module Virtus
     # @api private
     def self.setup(mod, inclusions = [Model], attribute_definitions = [])
       mod.instance_variable_set('@inclusions', inclusions)
-      mod.instance_variable_set('@attribute_definitions', attribute_definitions)
+      existing_attributes = mod.instance_variable_get('@attribute_definitions')
+      new_attributes = (existing_attributes || []) + attribute_definitions
+      mod.instance_variable_set('@attribute_definitions', new_attributes)
     end
 
     # Define an attribute in the module
@@ -57,8 +59,10 @@ module Virtus
       super
 
       if Class === object
-        @inclusions.each do |mod|
-          object.send(:include, mod) unless object.ancestors.include?(mod)
+        @inclusions.reject do |mod|
+          object.ancestors.include?(mod)
+        end.each do |mod|
+          object.send(:include, mod)
         end
         define_attributes(object)
       else

--- a/spec/unit/virtus/module_spec.rb
+++ b/spec/unit/virtus/module_spec.rb
@@ -140,4 +140,35 @@ describe Virtus, '.module' do
     end
   end
 
+  context 'with multiple other modules mixed into it' do
+    subject { Virtus.module }
+    let(:other)  { Module.new }
+    let(:yet_another)  { Module.new }
+
+    before do
+      other.send(:include, Virtus.module)
+      other.attribute :last_name, String, :default => 'Doe'
+      other.attribute :something_else
+      yet_another.send(:include, Virtus.module)
+      yet_another.send(:include, mod)
+      yet_another.send(:include, other)
+      yet_another.attribute :middle_name, String, :default => 'Foobar'
+      model.send(:include, yet_another)
+    end
+
+    it 'provides attributes for the model from all modules' do
+      expect(model.attribute_set[:name]).to be_kind_of(Virtus::Attribute)
+      expect(model.attribute_set[:something]).to be_kind_of(Virtus::Attribute)
+      expect(model.attribute_set[:last_name]).to be_kind_of(Virtus::Attribute)
+      expect(model.attribute_set[:something_else]).to be_kind_of(Virtus::Attribute)
+      expect(model.attribute_set[:middle_name]).to be_kind_of(Virtus::Attribute)
+    end
+
+    it 'includes the attributes from all modules' do
+      expect(model.new.attributes.keys).to eq(
+        [:name, :something, :last_name, :something_else, :middle_name]
+      )
+    end
+  end
+
 end


### PR DESCRIPTION
Looks like my patch in #276 only handled part of the module inclusion issues. 

This one handles the case where:
- you have modules `A`, `B`, `C`, and class `X`
- `C` includes both `A` and `B`, and may also have attributes of its own
- `X` includes `C`

Currently, some attributes would get lost depending on what order the `includes` happened in (see the unit tests).
