### PR TITLE
amending 1 documentation comment

### DIFF
--- a/lib/virtus/support/options.rb
+++ b/lib/virtus/support/options.rb
@@ -37,7 +37,7 @@ module Virtus
     # Defines which options are valid for a given attribute class
     #
     # @example
-    #   class MyAttribute < Virtus::Attribute::Object
+    #   class MyAttribute < Virtus::Attribute
     #     accept_options :foo, :bar
     #   end
     #


### PR DESCRIPTION
I was hoping that `accept_options` could work with a `Virtus.value_object`, but it seems to be accepted only by `Virtus::Attribute` isn't it?
I tried to mixed them together and had an error like

```
ArgumentError: wrong number of arguments (2 for 0..1)
from ~/.rvm/gems/ruby-2.1.2@hsa/gems/virtus-1.0.3/lib/virtus/instance_methods.rb:16:in `initialize'
```

**Not related with this PR**
The following example doesn't work:

```ruby
class NoisyString < Virtus::Attribute
  def coerce(value)
    coercer[value.class].to_string.upcase
  end
end
```