### PR TITLE
Added the option to localize the attributes

### DIFF
--- a/lib/virtus.rb
+++ b/lib/virtus.rb
@@ -244,6 +244,8 @@ require 'descendants_tracker'
 require 'equalizer'
 require 'axiom-types'
 require 'coercible'
+require 'i18n'
+I18n.enforce_available_locales = false
 
 require 'virtus/support/equalizer'
 require 'virtus/support/options'

--- a/lib/virtus/attribute.rb
+++ b/lib/virtus/attribute.rb
@@ -210,10 +210,24 @@ module Virtus
       frozen?
     end
 
+    # Returns if the attribute is localized
+    #
+    # @return [Boolean]
+    #
+    # @api public
+    def localized?
+      options[:localized]
+    end
+
     # @api private
     def define_accessor_methods(attribute_set)
-      attribute_set.define_reader_method(self, name,       options[:reader])
-      attribute_set.define_writer_method(self, "#{name}=", options[:writer])
+      if self.localized?
+        attribute_set.define_localized_reader_method(self, name,       options[:reader])
+        attribute_set.define_localized_writer_method(self, "#{name}=", options[:writer])
+      else
+        attribute_set.define_reader_method(self, name,       options[:reader])
+        attribute_set.define_writer_method(self, "#{name}=", options[:writer])
+      end
     end
 
     # @api private

--- a/lib/virtus/attribute_set.rb
+++ b/lib/virtus/attribute_set.rb
@@ -129,7 +129,24 @@ module Virtus
     #
     # @api private
     def define_reader_method(attribute, method_name, visibility)
-      define_method(method_name) { attribute.get(self) }
+      define_method(method_name) { 
+        attribute.get(self) 
+      }
+      send(visibility, method_name)
+    end
+
+    # Define a localized attribute reader method
+    # @param [Attribute] attribute
+    # @param [Symbol] method_name
+    # @param [Symbol] visibility
+    #
+    # @return [undefined]
+    #
+    # @api private
+    def define_localized_reader_method(attribute, method_name, visibility)
+      define_method(method_name) { 
+        attribute.get(self)["#{I18n.locale}"] rescue nil
+      }
       send(visibility, method_name)
     end
 
@@ -144,6 +161,24 @@ module Virtus
     # @api private
     def define_writer_method(attribute, method_name, visibility)
       define_method(method_name) { |value| attribute.set(self, value) }
+      send(visibility, method_name)
+    end
+
+    # Defines an localized attribute writer method
+    #
+    # @param [Attribute] attribute
+    # @param [Symbol] method_name
+    # @param [Symbol] visibility
+    #
+    # @return [undefined]
+    #
+    # @api private
+    def define_localized_writer_method(attribute, method_name, visibility)
+      define_method(method_name) { |value| 
+        new = attribute.get(self)
+        new ? (new["#{I18n.locale}"] = value) : (new = {"#{I18n.locale}" => value})
+        attribute.set(self, new) 
+      }
       send(visibility, method_name)
     end
 

--- a/spec/unit/virtus/attributes_localized_reader_spec.rb
+++ b/spec/unit/virtus/attributes_localized_reader_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+
+describe Virtus, '#attributes :localized => true' do
+
+  shared_examples_for 'attribute hash' do
+    it 'includes all attributes' do
+      I18n.locale = :en
+      subject.attributes = { :loc => 'Hello!' }
+
+      I18n.locale = :es
+      subject.attributes = { :loc => 'Hola!' }
+
+      I18n.locale = :de
+      subject.attributes = { :loc => 'Guten Tag!' }
+      expect(subject.instance_variable_get("@loc")).to eql({"en" => 'Hello!', "es" => 'Hola!', "de" => 'Guten Tag!'})
+
+      expect(subject.attributes).to eql(:loc => 'Guten Tag!')
+      I18n.locale = :en
+      expect(subject.attributes).to eql(:loc => 'Hello!')
+      I18n.locale = :es
+      expect(subject.attributes).to eql(:loc => 'Hola!')
+    end
+  end
+
+  context 'with a class' do
+    let(:model) {
+      Class.new {
+        include Virtus
+
+        attribute :loc,      String, :localized => true
+      }
+    }
+
+    it_behaves_like 'attribute hash' do
+      subject { model.new }
+    end
+  end
+
+  context 'with an instance' do
+    subject { model.new }
+
+    let(:model) { Class.new }
+
+    before do
+      subject.extend(Virtus)
+      subject.attribute :loc,      String, :localized => true
+    end
+
+    it_behaves_like 'attribute hash'
+  end
+end
+

--- a/virtus.gemspec
+++ b/virtus.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency('equalizer',           '~> 0.0', '>= 0.0.9')
   gem.add_dependency('coercible',           '~> 1.0')
   gem.add_dependency('axiom-types',         '~> 0.1')
+  gem.add_dependency('i18n',                '~> 0.6')
 end


### PR DESCRIPTION
This is a feature that for my tema and me is really useful. Is about localizing the attributes, to have the content of an attribute changing with the locale language. It uses I18n.locale to switch between languages. This feature works perfectly with MongoDB, because you can save Hashes.
If you want this feature, if you find it useful, i can also add the documentation on the README.md