### PR TITLE
Test for strict coercion of Array

### DIFF
--- a/spec/unit/virtus/attribute_spec.rb
+++ b/spec/unit/virtus/attribute_spec.rb
@@ -226,4 +226,38 @@ describe Virtus, '#attribute' do
       expect(subject.test).to be(:foo)
     end
   end
+
+
+  context 'strict mode' do
+    let(:model_with_integer_field) { model_class_with_integer_field.new }
+    let(:model_class_with_integer_field) {
+      Class.new {
+        include Virtus.model(:strict => true)
+
+        attribute :test, Integer, required: false
+      }
+    }
+
+    let(:model_with_array_field) { model_class_with_array_field.new }
+    let(:model_class_with_array_field) {
+      Class.new {
+        include Virtus.model(:strict => true)
+
+        attribute :test, Array, required: false
+      }
+    }
+
+    it 'raises coercion error on given invalid Integer' do
+      expect {
+        model_with_integer_field.test = 'this is not integer'
+      }.to raise_error Virtus::CoercionError
+    end
+
+    it 'raises coercion error on given invalid Array' do
+      expect {
+        model_with_array_field.test = 'this is not array'
+      }.to raise_error Virtus::CoercionError
+    end
+
+  end
 end


### PR DESCRIPTION
I think that strict mode for coercion of Array attribute should raise the coercion error exception, but it doesn't. I've added tests for strict mode for two attribute types (integer and array) to make sure that they work correctly. See that the test for integer attribute passes but for array fails.

Unfortunately I can't figure out what is problem but it seems to me that the issue is in this line: https://github.com/solnic/virtus/blob/master/lib/virtus/attribute/strict.rb#L14

In the code we have here changed `self` after evaluating `super`. It is because `Collection` attribute (it's a virtus' attribute type for Array) actually calls `coercion` of a superclass (`Attribute`) in this case but not current class'.

Could you approve that it's really a bug and help to fix this if it's true? Thanks!