### PR TITLE
Don't break on ActionDispatch reload.

### DIFF
--- a/lib/virtus/support/type_lookup.rb
+++ b/lib/virtus/support/type_lookup.rb
@@ -32,7 +32,7 @@ module Virtus
     #
     # @api public
     def determine_type(class_or_name)
-      @type_lookup_cache[class_or_name] ||= determine_type_and_cache(class_or_name)
+      @type_lookup_cache[class_or_name.to_s] ||= determine_type_and_cache(class_or_name)
     end
 
     # Return the default primitive supported


### PR DESCRIPTION
Rails reloads stuff in development environments. When it does, it creates new classes in memory with the updated version of the class. Old references to these classes can potentially leak memory, but more importantly, they're stale, pointing to the old version of the code. The previous implementation kept direct references to the classes after any types involved in coercion had been reloaded. This just uses a `String` as the cache key instead. Reloads generally won't change the name of the class, so this should also be more reliable as a cache. And if a class name does change, it'll be an entirely new key with no collision issues. This does assume that the value side of the cache does not need to be reloaded – but since Rails won't typically auto-reload that code anyway, it shouldn't be an issue.
