### PR TITLE
silence "warning: method redefined; discarding old attribute"

### DIFF
--- a/lib/virtus/builder.rb
+++ b/lib/virtus/builder.rb
@@ -70,6 +70,7 @@ module Virtus
         mod.define_singleton_method :included do |object|
           Builder.pending << object unless context.finalize?
           context.modules.each { |mod| object.send(:include, mod) }
+          object.singleton_class.class_eval { undef :attribute if method_defined?(:attribute) }
           object.define_singleton_method(:attribute, context.attribute_method)
         end
       end


### PR DESCRIPTION
```
virtus/lib/virtus/builder.rb:73: warning: method redefined; discarding old attribute
virtus/lib/virtus/builder/hook_context.rb:43: warning: previous definition of attribute was here
```

This PR silences the above warning by first undefining the method before defining a new one.

I do not know if this is a good tactic. I assume the defined singleton method can not call super anyway, otherwise there would be no warning.