### PR TITLE
Value objects do not have equality when using Virtus.value_object

### DIFF
--- a/lib/virtus/builder.rb
+++ b/lib/virtus/builder.rb
@@ -123,7 +123,8 @@ module Virtus
       super + [
         Extensions::AllowedWriterMethods,
         ValueObject::AllowedWriterMethods,
-        ValueObject::InstanceMethods
+        ValueObject::InstanceMethods,
+        ValueObject::ClassMethods
       ]
     end
 

--- a/lib/virtus/value_object.rb
+++ b/lib/virtus/value_object.rb
@@ -98,6 +98,10 @@ module Virtus
 
     module ClassMethods
 
+      def self.included(base)
+        base.extend(self)
+      end
+      
       # Define an attribute on the receiver
       #
       # The Attribute will have private writer methods (eg., immutable instances)

--- a/spec/integration/virtus/value_object_spec.rb
+++ b/spec/integration/virtus/value_object_spec.rb
@@ -7,7 +7,8 @@ describe Virtus::ValueObject do
         'GeoLocation'
       end
 
-      include Virtus::ValueObject
+      # include Virtus::ValueObject
+      include Virtus.value_object
 
       attribute :latitude,  Float
       attribute :longitude, Float


### PR DESCRIPTION
Given:
```
class Value
  include Virtus.value_object
  attribute :number, Integer
end
```

We expect: `Value.new(:number => 7) == Value.new(:number => 7)`

This behavior works as expected when using the deprecated `include Virtus::ValueObject` but is not preserved with the newer include. The equality behavior seems to be provided by `ValueObject::ClassMethods` which does not get extended when a value object class is constructed using the builder.

I took a quick crack at correcting the issue but I'm pretty sure I'm going down the wrong path. Including the class methods fixes equality but seems to introduce conflicting ideas about how to set options on attributes. Can you provide some guidance?