### PR TITLE
Add The `nullify_blank` option to nullify empty Strings when coercion fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,22 @@ end
 User.new :admin => "can't really say if true or false"
 ```
 
+## Nullify Blank Strings Mode
+
+If you want to replace empty Strings with `nil` values (since they can't be
+coerced into the expected type), you can use the `:nullify_blank` option.
+
+``` ruby
+class User
+  include Virtus.model(:nullify_blank => true)
+
+  attribute :birthday, Date
+end
+
+User.new(:birthday => "").birthday # => nil
+```
+
+
 ## Building modules with custom configuration
 
 You can also build Virtus modules that contain their own configuration.

--- a/lib/virtus.rb
+++ b/lib/virtus.rb
@@ -279,6 +279,7 @@ require 'virtus/attribute/accessor'
 require 'virtus/attribute/coercible'
 require 'virtus/attribute/strict'
 require 'virtus/attribute/lazy_default'
+require 'virtus/attribute/nullify_blank'
 
 require 'virtus/attribute/boolean'
 require 'virtus/attribute/collection'

--- a/lib/virtus/attribute.rb
+++ b/lib/virtus/attribute.rb
@@ -20,12 +20,13 @@ module Virtus
 
     include ::Equalizer.new(:type, :options)
 
-    accept_options :primitive, :accessor, :default, :lazy, :strict, :required, :finalize
+    accept_options :primitive, :accessor, :default, :lazy, :strict, :required, :finalize, :nullify_blank
 
     strict false
     required true
     accessor :public
     finalize true
+    nullify_blank false
 
     # @see Virtus.coerce
     #
@@ -174,6 +175,23 @@ module Virtus
     # @api public
     def strict?
       kind_of?(Strict)
+    end
+
+    # Return if the attribute is in the nullify blank coercion mode
+    #
+    # @example
+    #
+    #   attr = Virtus::Attribute.build(String, :nullify_blank => true)
+    #   attr.nullify_blank? # => true
+    #
+    #   attr = Virtus::Attribute.build(String, :nullify_blank => false)
+    #   attr.nullify_blank? # => false
+    #
+    # @return [Boolean]
+    #
+    # @api public
+    def nullify_blank?
+      kind_of?(NullifyBlank)
     end
 
     # Return if the attribute is accepts nil values as valid coercion output

--- a/lib/virtus/attribute/builder.rb
+++ b/lib/virtus/attribute/builder.rb
@@ -160,10 +160,11 @@ module Virtus
       def initialize_attribute
         @attribute = klass.new(type, options)
 
-        @attribute.extend(Accessor)    if options[:name]
-        @attribute.extend(Coercible)   if options[:coerce]
-        @attribute.extend(Strict)      if options[:strict]
-        @attribute.extend(LazyDefault) if options[:lazy]
+        @attribute.extend(Accessor)     if options[:name]
+        @attribute.extend(Coercible)    if options[:coerce]
+        @attribute.extend(NullifyBlank) if options[:nullify_blank]
+        @attribute.extend(Strict)       if options[:strict]
+        @attribute.extend(LazyDefault)  if options[:lazy]
 
         @attribute.finalize if options[:finalize]
       end

--- a/lib/virtus/attribute/nullify_blank.rb
+++ b/lib/virtus/attribute/nullify_blank.rb
@@ -1,0 +1,24 @@
+module Virtus
+  class Attribute
+
+    # Attribute extension which nullifies blank attributes when coercion failed
+    #
+    module NullifyBlank
+
+      # @see [Attribute#coerce]
+      #
+      # @api public
+      def coerce(input)
+        output = super
+
+        if !value_coerced?(output) && input.to_s.empty?
+          nil
+        else
+          output
+        end
+      end
+
+    end # NullifyBlank
+
+  end # Attribute
+end # Virtus

--- a/lib/virtus/configuration.rb
+++ b/lib/virtus/configuration.rb
@@ -12,6 +12,9 @@ module Virtus
     # Access the strict setting for this instance
     attr_accessor :strict
 
+    # Access the nullify_blank setting for this instance
+    attr_accessor :nullify_blank
+
     # Access the required setting for this instance
     attr_accessor :required
 
@@ -30,6 +33,7 @@ module Virtus
       @finalize        = options.fetch(:finalize, true)
       @coerce          = options.fetch(:coerce, true)
       @strict          = options.fetch(:strict, false)
+      @nullify_blank   = options.fetch(:nullify_blank, false)
       @required        = options.fetch(:required, true)
       @constructor     = options.fetch(:constructor, true)
       @mass_assignment = options.fetch(:mass_assignment, true)
@@ -59,6 +63,7 @@ module Virtus
       { :coerce             => coerce,
         :finalize           => finalize,
         :strict             => strict,
+        :nullify_blank      => nullify_blank,
         :required           => required,
         :configured_coercer => coercer }.freeze
     end

--- a/spec/integration/building_module_spec.rb
+++ b/spec/integration/building_module_spec.rb
@@ -19,6 +19,10 @@ describe 'I can create a Virtus module' do
         config.strict = true
       }
 
+      BlankModule = Virtus.model { |config|
+        config.nullify_blank = true
+      }
+
       class NoncoercedUser
         include NoncoercingModule
 
@@ -38,6 +42,13 @@ describe 'I can create a Virtus module' do
 
         attribute :stuff, Hash
         attribute :happy, Boolean, :strict => false
+      end
+
+      class BlankModel
+        include BlankModule
+
+        attribute :stuff, Hash
+        attribute :happy, Boolean, :nullify_blank => false
       end
     end
   end
@@ -60,6 +71,17 @@ describe 'I can create a Virtus module' do
     model = Examples::StrictModel.new
 
     expect { model.stuff = 'foo' }.to raise_error(Virtus::CoercionError)
+
+    model.happy = 'foo'
+
+    expect(model.happy).to eql('foo')
+  end
+
+  specify 'including a custom module with nullify blank enabled' do
+    model = Examples::BlankModel.new
+
+    model.stuff = ''
+    expect(model.stuff).to be_nil
 
     model.happy = 'foo'
 

--- a/spec/unit/virtus/attribute/class_methods/build_spec.rb
+++ b/spec/unit/virtus/attribute/class_methods/build_spec.rb
@@ -78,6 +78,14 @@ describe Virtus::Attribute, '.build' do
     it { is_expected.to be_strict }
   end
 
+  context 'when options specify nullify blank mode' do
+    let(:options) { { :nullify_blank => true } }
+
+    it_behaves_like 'a valid attribute instance'
+
+    it { is_expected.to be_nullify_blank }
+  end
+
   context 'when type is a string' do
     let(:type) { 'Integer' }
 

--- a/spec/unit/virtus/attribute/coerce_spec.rb
+++ b/spec/unit/virtus/attribute/coerce_spec.rb
@@ -7,10 +7,11 @@ describe Virtus::Attribute, '#coerce' do
 
   let(:object)   {
     described_class.build(String,
-      :coercer => coercer, :strict => strict, :required => required)
+      :coercer => coercer, :strict => strict, :required => required, :nullify_blank => nullify_blank)
   }
 
   let(:required) { true }
+  let(:nullify_blank) { false }
   let(:input)    { 1 }
   let(:output)   { '1' }
 
@@ -76,6 +77,53 @@ describe Virtus::Attribute, '#coerce' do
 
       expect(coercer).to have_received.call(input)
       expect(coercer).to have_received.success?(String, input)
+    end
+  end
+
+  context 'when the input is an empty String' do
+    let(:input) { '' }
+    let(:output) { '' }
+
+    context 'when nullify_blank is turned on' do
+      let(:nullify_blank) { true }
+      let(:strict) { false }
+      let(:require) { false }
+
+      it 'returns nil' do
+        mock(coercer).call(input) { input }
+        mock(coercer).success?(String, input) { false }
+
+        expect(subject).to be_nil
+
+        expect(coercer).to have_received.call(input)
+        expect(coercer).to have_received.success?(String, input)
+      end
+
+      it 'returns the ouput if it was coerced' do
+        mock(coercer).call(input) { output }
+        mock(coercer).success?(String, output) { true }
+
+        expect(subject).to be(output)
+
+        expect(coercer).to have_received.call(input)
+        expect(coercer).to have_received.success?(String, output)
+      end
+    end
+
+    context 'when both nullify_blank and strict are turned on' do
+      let(:nullify_blank) { true }
+      let(:strict) { true }
+
+      it 'does not raises an coercion error' do
+        mock(coercer).call(input) { input }
+        mock(coercer).success?(String, input) { false }
+
+        expect { subject }.not_to raise_error
+        expect(subject).to be_nil
+
+        expect(coercer).to have_received.call(input)
+        expect(coercer).to have_received.success?(String, input)
+      end
     end
   end
 end


### PR DESCRIPTION
Closes #310. 

I did a simple implementation based on what the code that supports the `strict` option, so let me know if I shouldn't take down this road. I still want to give a review of my own on this later and update the README documenting this feature before getting this merged :smile:.