### PR TITLE
325 mass assignment bug fix

### DIFF
--- a/lib/virtus/builder.rb
+++ b/lib/virtus/builder.rb
@@ -120,11 +120,7 @@ module Virtus
 
     # @api private
     def extensions
-      super + [
-        Extensions::AllowedWriterMethods,
-        ValueObject::AllowedWriterMethods,
-        ValueObject::InstanceMethods
-      ]
+      super << ValueObject::AllowedWriterMethods << ValueObject::InstanceMethods
     end
 
     # @api private

--- a/lib/virtus/class_inclusions.rb
+++ b/lib/virtus/class_inclusions.rb
@@ -13,7 +13,6 @@ module Virtus
     def self.included(descendant)
       super
       descendant.extend(ClassMethods)
-      descendant.extend(Extensions::AllowedWriterMethods)
       descendant.class_eval { include Methods }
       descendant.class_eval { include InstanceMethods }
       descendant.class_eval { include InstanceMethods::Constructor }

--- a/lib/virtus/extensions.rb
+++ b/lib/virtus/extensions.rb
@@ -18,7 +18,6 @@ module Virtus
       object.instance_eval do
         extend Methods
         extend InstanceMethods
-        extend AllowedWriterMethods
         extend InstanceMethods::MassAssignment
       end
     end
@@ -75,23 +74,6 @@ module Virtus
         include(::Equalizer.new(*attribute_set.map(&:name)))
       end
 
-      private
-
-      # Return an attribute set for that instance
-      #
-      # @return [AttributeSet]
-      #
-      # @api private
-      def attribute_set
-        @attribute_set
-      end
-
-    end # Methods
-
-    module AllowedWriterMethods
-      WRITER_METHOD_REGEXP   = /=\z/.freeze
-      INVALID_WRITER_METHODS = %w[ == != === []= attributes= ].to_set.freeze
-
       # The list of writer methods that can be mass-assigned to in #attributes=
       #
       # @return [Set]
@@ -106,8 +88,18 @@ module Virtus
           end
       end
 
-    end # AllowedWriterMethods
+      private
+
+      # Return an attribute set for that instance
+      #
+      # @return [AttributeSet]
+      #
+      # @api private
+      def attribute_set
+        @attribute_set
+      end
+
+    end # Methods
 
   end # module Extensions
-
 end # module Virtus

--- a/lib/virtus/instance_methods.rb
+++ b/lib/virtus/instance_methods.rb
@@ -14,7 +14,7 @@ module Virtus
       #
       # @api private
       def initialize(attributes = nil)
-        self.class.attribute_set.set(self, attributes) if attributes
+        attribute_set.set(self, attributes) if attributes
         set_default_attributes
       end
 

--- a/lib/virtus/model.rb
+++ b/lib/virtus/model.rb
@@ -51,7 +51,6 @@ module Virtus
       # @api private
       def self.included(descendant)
         super
-        descendant.extend(Extensions::AllowedWriterMethods)
         descendant.send(:include, InstanceMethods::MassAssignment)
       end
       private_class_method :included
@@ -59,7 +58,6 @@ module Virtus
       # @api private
       def self.extended(descendant)
         super
-        descendant.extend(Extensions::AllowedWriterMethods)
         descendant.extend(InstanceMethods::MassAssignment)
       end
       private_class_method :extended

--- a/spec/integration/attributes_attribute_spec.rb
+++ b/spec/integration/attributes_attribute_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+
+describe "Adding attribute called 'attributes'" do
+
+  context "when mass assignment is disabled" do
+    before do
+      module Examples
+        class User
+          include Virtus.model(mass_assignment: false)
+
+          attribute :attributes
+        end
+      end
+    end
+
+    it "allows model to use `attributes` attribute" do
+      user = Examples::User.new
+      expect(user.attributes).to eq(nil)
+      user.attributes = "attributes string"
+      expect(user.attributes).to eq("attributes string")
+    end
+
+    it "doesn't accept `attributes` key in initializer" do
+      user = Examples::User.new(attributes: 'attributes string')
+      expect(user.attributes).to eq(nil)
+    end
+  end
+end


### PR DESCRIPTION
So I decided to fix the bug referenced in #325. 
This PR reverts commit a385ca2e6b724ec400c05a4bc7e55bfb9976c1c9 and adds specs for situation when user wants to use "attributes" as attribute name.

I tried to first keep the initial intention of a385ca2e6b724ec400c05a4bc7e55bfb9976c1c9 and make `AllowedWriterMethods` module be included only when mass-assignment is turned on, however I found it being tied into object initialization pretty tightly:
https://github.com/solnic/virtus/blob/d494b95e4181cda44c44d58566cee2185f9a6d9e/lib/virtus/attribute_set.rb#L169
https://github.com/solnic/virtus/blob/d494b95e4181cda44c44d58566cee2185f9a6d9e/lib/virtus/instance_methods.rb#L16
so it wouldn't be that easy of a change. So my suggestion is to revert that old commit (since it's intended goal is not reached anyway, unfortunately) to fix a bug and keep it as a reference for future when this refactoring can be actually done.

@solnic what do you think?