### PR TITLE
Add #update_attributes in mass assignment

### DIFF
--- a/lib/virtus/instance_methods.rb
+++ b/lib/virtus/instance_methods.rb
@@ -70,6 +70,7 @@ module Virtus
       def attributes=(attributes)
         attribute_set.set(self, attributes)
       end
+      alias_method :update_attributes, :attributes=
 
     end # MassAssignment
 

--- a/spec/integration/mass_assignment_with_accessors_spec.rb
+++ b/spec/integration/mass_assignment_with_accessors_spec.rb
@@ -38,6 +38,12 @@ describe "mass assignment with accessors" do
     expect(subject.subcategory).to eq('Furniture')
   end
 
+  specify 'can be updated with #update_attributes' do
+    subject.update_attributes({:categories => ['Home', 'Furniture']})
+    expect(subject.category).to eq('Home')
+    expect(subject.subcategory).to eq('Furniture')
+  end
+
   specify 'respects accessor visibility' do
     expect(subject.id).not_to eq(100)
   end


### PR DESCRIPTION
`#attributes=` method behaves like *set these attributes for this object* in my mind, but works like *update provided attributes in object*, and I'm feel wrong when using it in this way.

```ruby
require 'virtus'

class User
  include Virtus.model

  attribute :name
  attribute :age
end

user = User.new(name: 'John Doe', age: 21)
# => #<User:0x007fe7b38d71e0 @name="John Doe", @age=21>

user.attributes = { name: 'John Snow' }
# => #<User:0x007fe7b38d71e0 @name="John Snow", @age=21>
# maybe there could be #update_attributes
```

What do you think?