### PR TITLE
Virtus::Attribute::Collection.value_coerced? override.

### DIFF
--- a/lib/virtus/attribute/collection.rb
+++ b/lib/virtus/attribute/collection.rb
@@ -80,6 +80,11 @@ module Virtus
         end
       end
 
+      # @api public
+      def value_coerced?(value)
+        super && value.all? { |item| member_type.value_coerced? item }
+      end
+
       # @api private
       def finalize
         return self if finalized?

--- a/spec/unit/virtus/attribute/collection/value_coerced_predicate_spec.rb
+++ b/spec/unit/virtus/attribute/collection/value_coerced_predicate_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'set'
+
+describe Virtus::Attribute::Collection, '#value_coerced?' do
+  subject { object.value_coerced?(input) }
+
+  let(:object) { described_class.build(Array[Integer]) }
+
+  context 'when input has correctly typed members' do
+    let(:input) { [1, 2, 3] }
+
+    it { is_expected.to be(true) }
+  end
+
+  context 'when input has incorrectly typed members' do
+    let(:input) { [1, 2, '3'] }
+
+    it { is_expected.to be(false) }
+  end
+
+  context 'when the collection type is incorrect' do
+    let(:input) { Set[1, 2, 3] }
+
+    it { is_expected.to be(false) }
+  end
+
+  context 'when the input is empty' do
+    let(:input) { [] }
+    it { is_expected.to be(true) }
+  end
+end


### PR DESCRIPTION
Added override of `Virtus::Attribute.value_coerced?` to
`Virtus::Attribute::Collection`, which checks collection
members against the expected member type. Prevents e.g.
`Virtus::Attribute.build(Array[Integer]).value_coerced? %w{1 2 3}`
from returning `true`.