### PR TITLE
Don't coerce nil for collection attributes when required is false

### DIFF
--- a/lib/virtus/attribute/collection.rb
+++ b/lib/virtus/attribute/collection.rb
@@ -71,7 +71,7 @@ module Virtus
 
       # @api public
       def coerce(value)
-        coerced = super
+        coerced = value.nil? && !required? ? nil : super
 
         return coerced unless coerced.respond_to?(:each_with_object)
 

--- a/spec/unit/virtus/attribute/collection/coerce_spec.rb
+++ b/spec/unit/virtus/attribute/collection/coerce_spec.rb
@@ -61,14 +61,27 @@ describe Virtus::Attribute::Collection, '#coerce' do
 
     let(:object) {
       described_class.build(
-        Array[member_primitive], coercer: coercer, member_type: member_type
+        Array[member_primitive], coercer: coercer, member_type: member_type, required: required
       )
     }
 
-    it 'returns nil' do
-      mock(coercer).call(input) { input }
+    context 'when required' do
+      let(:required) { true }
+      let(:output)   { Array(input) }
 
-      expect(subject).to be(input)
+      it 'returns an empty array' do
+        mock(coercer).call(input) { output }
+
+        expect(subject).to eq(output)
+      end
+    end
+
+    context 'when not required' do
+      let(:required) { false }
+
+      it 'returns nil' do
+        expect(subject).to be(input)
+      end
     end
   end
 end


### PR DESCRIPTION
Without this fix, collection attributes can never be set to nil when
coercion is enabled (because the coercer coerces nil to an empty array).

This should fix #334. 

I originally suggested a change in a more central location, see [this comment](/solnic/virtus/issues/334#issuecomment-190266441), but looking at the specs it seemed more appropriate to make this change only for collection attributes.
