### PR TITLE
Allow to extend a Virtus model with per-instance attributes

### DIFF
--- a/lib/virtus/attribute_set.rb
+++ b/lib/virtus/attribute_set.rb
@@ -8,6 +8,12 @@ module Virtus
     def self.create(descendant)
       if descendant.respond_to?(:superclass) && descendant.superclass.respond_to?(:attribute_set)
         parent = descendant.superclass.public_send(:attribute_set)
+      elsif !descendant.is_a?(Module)
+        if descendant.respond_to?(:attribute_set, true) && descendant.send(:attribute_set)
+          parent = descendant.send(:attribute_set)
+        elsif descendant.class.respond_to?(:attribute_set)
+          parent = descendant.class.attribute_set
+        end
       end
       descendant.instance_variable_set('@attribute_set', AttributeSet.new(parent))
     end

--- a/spec/integration/mixing_class_and_instance_attributes_spec.rb
+++ b/spec/integration/mixing_class_and_instance_attributes_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'an instance from a class with attributes' do
+  before do
+    module Examples
+      class BaseUser
+        include Virtus.model
+        attribute :name, String, default: 'John'
+      end
+    end
+  end
+
+  let(:user) { Examples::BaseUser.new }
+
+  specify 'can be extended with per-instance attributes' do
+    user.extend(Virtus.model)
+    user.attribute(:active, Virtus::Attribute::Boolean, default: true, lazy: true)
+
+    expect(user.name).to eq 'John'
+    expect(user.active).to eq true
+
+    expect(user.to_h).to eq({:name=>"John", :active=>true})
+  end
+
+  specify 'can be extended with per-instance attributes and still allows adding attributes to the class' do
+    user.extend(Virtus.model)
+    user.attribute(:active, Virtus::Attribute::Boolean, default: true, lazy: true)
+
+    Examples::BaseUser.attribute(:just_added, String, default: 'it works!', lazy: true)
+    expect(user.just_added).to eq('it works!')
+  end
+
+  specify 'can be extended multiple times with per-instance attributes' do
+    user.extend(Virtus.model)
+    user.attribute(:active, Virtus::Attribute::Boolean, default: true, lazy: true)
+
+    user.extend(Virtus.model) # corner case, but might happen inadvertently
+    user.attribute(:age, Integer, default: 42, lazy: true)
+
+    expect(user.name).to eq 'John'
+    expect(user.active).to eq true
+    expect(user.age).to eq 42
+
+    expect(user.to_h).to eq({:name=>"John", :active=>true, :age=>42})
+  end
+end


### PR DESCRIPTION
Hello,
This is my first contribution to Virtus, please review.

Currently, creating an instance of a class with Virtus attributes,
and then extending it with `user.extend(Virtus.model)` to add dynamic attributes breaks.
This PR fixes it.
```ruby
class User
  include Virtus.model
  attribute :name, String, default: 'John', lazy: true
end

user = User.new
user.extend(Virtus.model)
user.attribute(:active, Virtus::Attribute::Boolean, default: true, lazy: true)

p user.to_h # currently {:active=>true}
# But should be {:name=>"John", :active=>true}
```

* Reuse the concept of a parent AttributeSet and inherit
  from the class attribute_set when creating an instance attribute_set.
* Related to #122.
* See https://stackoverflow.com/q/44046603/388803 for more context.