### PR TITLE
Fixed determining Boolean from `false`

### DIFF
--- a/lib/virtus/attribute/boolean.rb
+++ b/lib/virtus/attribute/boolean.rb
@@ -1,6 +1,21 @@
 module Virtus
   class Attribute
 
+    # An "ancestor" for both TrueClass and FalseClass
+    # Used to correctly build Attribute::Boolean from
+    # true or false
+    #
+    # Needs to be a descendant of TrueClass in order
+    # to allow Axiom::Type.infer to infer
+    # Axiom::Types::Boolean from BooleanPrimitive
+    #
+    # @private
+    class BooleanPrimitive < TrueClass
+      def self.>=(klass)
+        TrueClass >= klass || FalseClass >= klass
+      end
+    end
+
     # Boolean attribute allows true or false values to be set
     # Additionally it adds boolean reader method, like "admin?"
     #
@@ -15,7 +30,7 @@ module Virtus
     #   post.published?  # => false
     #
     class Boolean < Attribute
-      primitive TrueClass
+      primitive BooleanPrimitive
 
       # @api private
       def self.build_type(*)

--- a/lib/virtus/support/type_lookup.rb
+++ b/lib/virtus/support/type_lookup.rb
@@ -83,7 +83,7 @@ module Virtus
       type = nil
       descendants.select(&:primitive).reverse_each do |descendant|
         descendant_primitive = descendant.primitive
-        next unless primitive <= descendant_primitive
+        next unless descendant_primitive >= primitive
         type = descendant if type.nil? or type.primitive > descendant_primitive
       end
       type

--- a/spec/unit/virtus/attribute/class_methods/build_spec.rb
+++ b/spec/unit/virtus/attribute/class_methods/build_spec.rb
@@ -177,4 +177,18 @@ describe Virtus::Attribute, '.build' do
       it { is_expected.to be < Axiom::Types::Collection }
     end
   end
+
+  context 'when building from Boolean values' do
+    context 'when building from true' do
+      let(:type) { true }
+
+      it { is_expected.to be_instance_of(Virtus::Attribute::Boolean) }
+    end
+
+    context 'when building from false' do
+      let(:type) { false }
+
+      it { is_expected.to be_instance_of(Virtus::Attribute::Boolean) }
+    end
+  end
 end


### PR DESCRIPTION
This is a small hack, that fixes incorrect behaviour in #377.

The problem, as I see it, is that `Virtus::Attribute::Boolean` has only `TrueClass` as a primitive. This makes `Virtus::TypeLookup` to determine correctly only `true`, because it executes `TrueClass >= true.class`. The same expression with `false` - `TrueClass >= false.class` will not allow TypeLookup to think that false is somehow connected to Virtus::Attribute::Boolean.

I replaced TrueClass primitive with BooleanPrimitive, that returns `true` when comparing with both TrueClass and FalseClass, thus allowing TypeLookup to connect `true` and `false` values with `Virtus::Attribute::Boolean`.