### PR TITLE
Fix but in coerce when Rails 5 params are passed in

### DIFF
--- a/lib/virtus/attribute_set.rb
+++ b/lib/virtus/attribute_set.rb
@@ -193,9 +193,13 @@ module Virtus
     #
     # @api private
     def coerce(attributes)
-      ::Hash.try_convert(attributes) or raise(
-        NoMethodError, "Expected #{attributes.inspect} to respond to #to_hash"
-      )
+      if attributes.respond_to?(:to_unsafe_hash)
+        attributes.to_unsafe_hash
+      elsif hash_attributes = ::Hash.try_convert(attributes)
+        hash_attributes
+      else
+        raise( NoMethodError, "Expected #{attributes.inspect} to respond to #to_hash" )
+      end
     end
 
     # @api private

--- a/spec/unit/virtus/attributes_writer_spec.rb
+++ b/spec/unit/virtus/attributes_writer_spec.rb
@@ -14,6 +14,32 @@ describe Virtus, '#attributes=' do
 
       expect(subject.test).to eql('Hello World')
     end
+
+    context "with Rails 5 parameters" do
+      class FakeParams
+
+        def initialize(hash)
+          @hash = hash
+        end
+
+        def to_hash
+          raise "Cannot be called on unsafe params"
+        end
+
+        def to_unsafe_hash
+          @hash
+        end
+      end
+
+      it "safely assigns the hash" do
+        subject.attributes = FakeParams.new({ :test => 'Hello World' })
+        expect(subject.test).to eql('Hello World')
+      end
+
+      it "handles properly if the attributes are not hash like" do
+        expect { subject.attributes = 1 }.to raise_error(NoMethodError)
+      end
+    end
   end
 
   context 'with a class' do


### PR DESCRIPTION
Since parameters in Rails 5 no longer sub class from Hash and blow up
when you try to call to_hash on them when they are not permitted the
coerce method in Virtus was no longer working. Since the hash here is
not mass assigned but instead only permits known attributes it is safe
to call `.to_unsafe_hash` if it is defined on the attributes. If not we
fall back to the previous behavior.

This also adds specs to capture the bahavior I was seeing on Rails 5.