### PR TITLE
Fixed documentation that implies the introduction of a mutability bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ end
 class User
   include Virtus.model
 
-  attribute :info, Json, default: {}
+  attribute :info, Json, default: ->(_, _) { {} }
 end
 
 user = User.new


### PR DESCRIPTION
Setting the default value to a hash (or empty array, or any other mutable object) can cause mutability/side-effect problems to be introduced. These are very hard and time-consuming to track down.

For example:

    u1 = User.new
    u1.info[:something] = 1

    u2 = User.new
    u2.info[:something] # => 1

In the above example, one would expect `u2.info[:something]` to return `nil`, however because the default value Hash is shared between all users, `u2.info[:something]` returns `1`.

Using the lambda means that a new Hash will be created each time a new user is created, avoiding the above side-effect issue:

    u1 = User.new
    u1.info[:something] = 1

    u2 = User.new
    u2.info[:something] # => nil